### PR TITLE
ID-11.2: Add the ID name of the chromosomes to the whole_chromosomes …

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -40,9 +40,8 @@ def find_kmers_recursively_in_genome(organism_name, gcf, data, save_to_db):
 
 @DBConnection
 @Timer
-def whole_MFA_sequence(organism_name, sequence_name, gcf, sequence, save_to_db):
-    sequence_manager = SequenceManager(sequence=sequence, organism_name=organism_name,
-                                       sequence_name=sequence_name)
+def whole_MFA_sequence(gcf, sequence, save_to_db):
+    sequence_manager = SequenceManager(sequence=sequence)
     sequence_manager.calculate_multifractal_analysis_values()
 
     if save_to_db:
@@ -52,9 +51,8 @@ def whole_MFA_sequence(organism_name, sequence_name, gcf, sequence, save_to_db):
 
 @DBConnection
 @Timer
-def find_kmers_recursively_in_sequence(organism_name, sequence_name, gcf, sequence, save_to_db):
-    sequence_manager = SequenceManager(sequence=sequence, organism_name=organism_name,
-                                       sequence_name=sequence_name)
+def find_kmers_recursively_in_sequence(gcf, sequence, save_to_db):
+    sequence_manager = SequenceManager(sequence=sequence)
     sequence_manager.calculate_multifractal_analysis_values()
     kmers_list = sequence_manager.find_only_kmers_recursively()
     if save_to_db:
@@ -65,17 +63,17 @@ def find_kmers_recursively_in_sequence(organism_name, sequence_name, gcf, sequen
 @DBConnection
 @Timer
 def regions_MFA_genome(organism_name, gcf, data, regions_number, save_to_db):
-    region_genome_manager = RegionGenomeManager(genome_data=data, organism_name=organism_name,
-                                                regions_number=regions_number)
+    region_genome_manager = RegionGenomeManager(genome_data=data, regions_number=regions_number,
+                                                organism_name=organism_name)
     region_genome_manager.calculate_multifractal_analysis_values(GCF=gcf, save_to_db=save_to_db)
     #region_genome_manager.save_to_db_after_execution(GCF=gcf)
 
 
 @DBConnection
 @Timer
-def regions_MFA_sequence(organism_name, sequence_name, gcf, sequence, regions_number, save_to_db):
-    region_sequence_manager = RegionSequenceManager(sequence=sequence, organism_name=organism_name,
-                                                regions_number=regions_number, sequence_name=sequence_name)
+def regions_MFA_sequence(gcf, sequence, regions_number, save_to_db):
+
+    region_sequence_manager = RegionSequenceManager(sequence=sequence, regions_number=regions_number)
     region_sequence_manager.calculate_multifractal_analysis_values()
 
     if save_to_db:

--- a/command.py
+++ b/command.py
@@ -102,7 +102,10 @@ def find_kmers_sequence_command(args):
 
     if args.path:
         if args.method == 'r':
-            sequence = Sequence(sequence=loader.read_fasta_sequence(file_path=args.path))
+            sequence = Sequence(sequence=loader.read_fasta_sequence(file_path=args.path),
+                                name=loader.extract_file_name(file_path=args.path),
+                                organism_name=loader.get_organism_name(),
+                                refseq_accession_number=loader.extract_refseq_accession_number(args.path))
             save_to_db = False if args.save_to_db == 'false' else True
 
             load_organism(organism_name=loader.get_organism_name(), gcf=loader.get_gcf(),
@@ -121,7 +124,6 @@ def download_command(args):
     if args.name:
         organism = args.name
         loader.set_organism(organism)
-        logger.debug(loader.get_organism_folder())
         remove_files(organism_folder=loader.get_organism_folder())
         execute_download_command(organism_folder=loader.get_organism_folder(), download_url=loader.get_download_url())
         clean_directory(organism_folder=loader.get_organism_folder())
@@ -171,7 +173,10 @@ def analyze_sequence_command(args):
         logger.error("Please provide either a -name (lowercase name or GCF).")
 
     if args.path:
-        sequence = Sequence(sequence=loader.read_fasta_sequence(file_path=args.path))
+        sequence = Sequence(sequence=loader.read_fasta_sequence(file_path=args.path),
+                            name=loader.extract_file_name(file_path=args.path),
+                            organism_name=loader.get_organism_name(),
+                            refseq_accession_number=loader.extract_refseq_accession_number(args.path))
         save_to_db = False if args.save_to_db == 'false' else True
         _validate_mode_analyzing_sequence(args, sequence, save_to_db=save_to_db)
     else:
@@ -183,15 +188,11 @@ def _validate_mode_analyzing_sequence(args, sequence: Sequence, save_to_db: bool
         if args.mode == 'whole':
             load_organism(organism_name=loader.get_organism_name(), gcf=loader.get_gcf(),
                           amount_chromosomes=loader.get_amount_chromosomes())
-            whole_MFA_sequence(organism_name=loader.get_organism_name(),
-                               sequence_name=loader.extract_file_name(file_path=args.path),
-                               gcf=loader.get_gcf(), sequence=sequence, save_to_db=save_to_db)
+            whole_MFA_sequence(gcf=loader.get_gcf(), sequence=sequence, save_to_db=save_to_db)
         elif args.mode == 'regions':
             load_organism(organism_name=loader.get_organism_name(), gcf=loader.get_gcf(),
                           amount_chromosomes=loader.get_amount_chromosomes())
-            regions_MFA_sequence(organism_name=loader.get_organism_name(),
-                                 sequence_name=loader.extract_file_name(file_path=args.path),
-                                 gcf=loader.get_gcf(), sequence=sequence,
+            regions_MFA_sequence(gcf=loader.get_gcf(), sequence=sequence,
                                  regions_number=loader.get_regions_number(), save_to_db=save_to_db)
         else:
             logger.error("Enter a valid mode (whole or regions)")

--- a/load.py
+++ b/load.py
@@ -31,7 +31,7 @@ class Loader:
 
         return sequence
 
-    def extract_sequence_name(self, file_path) -> str:
+    def extract_refseq_accession_number(self, file_path) -> str:
         with open(file_path, 'r') as fna_file:
             for record in SeqIO.parse(fna_file, 'fasta'):
                 # Extract the sequence name (the part before the first space)
@@ -51,7 +51,7 @@ class Loader:
                                   'inf'))
 
         return [
-            {"path": os.path.join(path, file), "name": file.split(".")[0]}
+            {"path": os.path.join(path, file), "name": file.split(".")[0], "organism_name": self.organism}
             for file in sorted_files
         ]
 

--- a/repeats.py
+++ b/repeats.py
@@ -1,5 +1,6 @@
 from src.Biocode.services.RMRepeatsWholeChromosomesService import RMRepeatsWholeChromosomesService
 from src.Biocode.services.RepeatsService import RepeatsService
+from src.Biocode.services.WholeChromosomesService import WholeChromosomesService
 
 from load import loader
 from utils.decorators import Timer, DBConnection
@@ -35,12 +36,14 @@ def load_RM_repeats_from_file(path):
     df = _import_file_out(path)
     repeats_service = RepeatsService()
     rmRepeatsWholeChromosomesService= RMRepeatsWholeChromosomesService()
+    wholeChromosomesService = WholeChromosomesService()
 
     for _, row in df.iterrows():
         repeat_id = repeats_service.insert(record=(row['name'], row['class_family'], 'RM'))
+        whole_chromosome_id = wholeChromosomesService.extract_id_by_refseq_accession_number(row['sequence'])
         record = (
             repeat_id,
-            2, #CHANGE - HARDCODED
+            whole_chromosome_id,
             row['sw_score'],
             row['percentage_divergence'],
             row['percentage_deletions'],

--- a/resources/schema.sql
+++ b/resources/schema.sql
@@ -10,15 +10,17 @@ CREATE TABLE organisms (
 CREATE TABLE whole_chromosomes (
     id INTEGER PRIMARY KEY,
     name VARCHAR,
+    refseq_accession_number VARCHAR,
     organism_id INTEGER REFERENCES organisms(id),
     cover_percentage REAL,
     cover REAL[],
     size INTEGER
-)
+);
 
 CREATE TABLE region_chromosomes (
     id INTEGER PRIMARY KEY,
     name VARCHAR,
+    refseq_accession_number VARCHAR,
     organism_id INTEGER REFERENCES organisms(id),
     cover_percentage REAL,
     cover REAL[],
@@ -26,7 +28,7 @@ CREATE TABLE region_chromosomes (
     region_number INTEGER,
     size INTEGER,
     whole_chromosome_id INTEGER REFERENCES whole_chromosomes(id)
-)
+);
 
 -- Create mi_grids table with foreign key constraint
 CREATE TABLE mi_grids (
@@ -70,7 +72,7 @@ CREATE TABLE repeats_whole_chromosomes (
     whole_chromosomes_id INTEGER REFERENCES whole_chromosomes(id),
     start_position INTEGER,
     end_position INTEGER,
-    size INTEGER,
+    size INTEGER
 );
 
 

--- a/src/Biocode/managers/DBConnectionManager.py
+++ b/src/Biocode/managers/DBConnectionManager.py
@@ -25,11 +25,9 @@ class DBConnectionManager:
         check_query = f'SELECT * FROM {table_name} WHERE {" AND ".join([f"{col} = ?" for col in columns if col != pk])};'
         DBConnectionManager.cursor.execute(check_query, tuple(record))
         existing_record = DBConnectionManager.cursor.fetchone()
-        logger.debug("Existing record:")
-        logger.debug(existing_record)
         if existing_record:
             existing_record_id = existing_record[0]  # Assuming the id is the first element of the tuple
-            logger.info(f"Existing record with id {existing_record_id}")
+            logger.info(f"Existing record with id {existing_record_id} in table {table_name}")
             return existing_record_id
         else:
             insert_query = f'INSERT INTO {table_name} ({", ".join(columns)}) VALUES ({", ".join(["?"] * len(columns))});'

--- a/src/Biocode/managers/GenomeManager.py
+++ b/src/Biocode/managers/GenomeManager.py
@@ -97,7 +97,8 @@ class GenomeManager(GenomeManagerInterface):
         organism_id = int(self.organisms_service.extract_by_GCF(GCF=GCF).loc[0, 'id'])
 
         for index, result in enumerate(self.mfa_results):
-            chromosome_id = self.whole_chromosomes_service.insert(record=(result['sequence_name'], organism_id,
+            chromosome_id = self.whole_chromosomes_service.insert(record=(result['sequence_name'],
+                                                                          result['refseq_accession_number'],organism_id,
                                                                self.cover_percentage[index],
                                                                list_to_str(self.cover[index]),
                                                                result['sequence_size']))

--- a/src/Biocode/managers/GenomeManagerInterface.py
+++ b/src/Biocode/managers/GenomeManagerInterface.py
@@ -50,7 +50,7 @@ class GenomeManagerInterface:
 
         # name of organism
         self.organism_name = organism_name
-        # mfa results
+        # mfa resultsc
         self.mfa_results = []
         # degrees of multifractality
         self.degrees_of_multifractality = []
@@ -91,8 +91,6 @@ class GenomeManagerInterface:
     def calculate_multifractal_analysis_values(self, GCF: str, save_to_db: bool):
         """Generate mfa generators, generate mfa values, the cover and cover
         percentage and send them to the DB"""
-
-        logger.debug("GenomeManagerInterface.calculate_multifractal_analysis_values")
         for manager in self.managers:
             logger.info(f"Starting chromosome: {manager.get_sequence_name()}")
             manager.calculate_multifractal_analysis_values()

--- a/src/Biocode/mfa/MFA.py
+++ b/src/Biocode/mfa/MFA.py
@@ -114,7 +114,8 @@ class MFA:
             'tau_q_values': self.tau_q_values,
             'DDq': self.DDq,
             'sequence_name': self.sequence.get_name(),
-            'sequence_size': self.sequence.get_size()
+            'sequence_size': self.sequence.get_size(),
+            'refseq_accession_number': self.sequence.get_refseq_accession_number()
         }
         return self.result
 

--- a/src/Biocode/sequences/Genome.py
+++ b/src/Biocode/sequences/Genome.py
@@ -3,10 +3,13 @@ from src.Biocode.sequences.Sequence import Sequence
 
 from src.Biocode.sequences.RegionSequence import RegionSequence
 
+from load import loader
+from utils.logger import logger
 
 class Genome:
     def __init__(self, chromosomes: list[Sequence] = None, chromosomes_data: list[dict] = None,
                  regions_number: int = 0):
+
         if regions_number < 0:
             raise Exception("Enter a valid regions_number for the Genome")
         elif regions_number == 0:
@@ -15,17 +18,23 @@ class Genome:
             elif chromosomes_data:
                 self.chromosomes = []
                 for data in chromosomes_data:
-                    self.chromosomes.append(Sequence(str(SeqIO.read(data['path'], "fasta").seq), name=data['name']))
+                    self.chromosomes.append(Sequence(str(SeqIO.read(data['path'], "fasta").seq), name=data['name'],
+                                        organism_name=data['organism_name'],
+                                        refseq_accession_number=loader.extract_refseq_accession_number(data['path'])))
         else:  # with regions number
             if chromosomes:
-                self.chromosomes = [RegionSequence(sequence=chromosome.get_sequence(), regions_number=regions_number)
+                self.chromosomes = [RegionSequence(sequence=chromosome.get_sequence(), regions_number=regions_number,
+                                                   refseq_accession_number=chromosome.get_refseq_accession_number(),
+                                                   organism_name=chromosome.get_organism_name())
                                     for chromosome in chromosomes]
             elif chromosomes_data:
                 self.chromosomes = []
                 for data in chromosomes_data:
                     self.chromosomes.append(
                         RegionSequence(sequence=str(SeqIO.read(data['path'], "fasta").seq), name=data['name'],
-                                       regions_number=regions_number))
+                                       regions_number=regions_number,
+                                       refseq_accession_number=loader.extract_refseq_accession_number(data['path']),
+                                       organism_name=data['organism_name']))
 
         self.number_of_chromosomes = len(self.chromosomes)
         self.chromosomes_names = [chromosome.get_name() for chromosome in self.chromosomes]

--- a/src/Biocode/sequences/RegionSequence.py
+++ b/src/Biocode/sequences/RegionSequence.py
@@ -3,8 +3,10 @@ from src.Biocode.sequences.Sequence import Sequence
 
 
 class RegionSequence(Sequence):
-    def __init__(self, sequence: str = None, sequence_data: dict = None, regions_number: int = 0, name: str = None):
-        super().__init__(sequence=sequence, sequence_data=sequence_data, name=name)
+    def __init__(self, sequence: str = None, sequence_data: dict = None, regions_number: int = 0, name: str = None,
+                 refseq_accession_number: str = None, organism_name: str = None):
+        super().__init__(sequence=sequence, sequence_data=sequence_data, name=name,
+                         refseq_accession_number=refseq_accession_number, organism_name= organism_name)
         self.region_common_size = None
         self.regions_number = regions_number
         self.regions = []

--- a/src/Biocode/sequences/Sequence.py
+++ b/src/Biocode/sequences/Sequence.py
@@ -2,16 +2,20 @@ from Bio import SeqIO
 
 
 class Sequence:
-    def __init__(self, sequence: str = None, sequence_data: dict = None, name: str = None):
+    def __init__(self, sequence: str = None, sequence_data: dict = None, name: str = None,
+                 refseq_accession_number: str = None, organism_name: str = None):
         if sequence:
             self.sequence = sequence
             self.name = name
+            self.refseq_accession_number = refseq_accession_number
         elif sequence_data:
             self.sequence = str(SeqIO.read(sequence_data['path'], "fasta").seq)
             self.name = sequence_data['name']
+            self.refseq_accession_number = sequence_data['refseq_accession_number']
         self.size = len(self.sequence)
         self.cover = []
         self.cover_percentage = 0.0
+        self.organism_name = organism_name
 
     def get_sequence(self) -> str:
         return self.sequence
@@ -36,3 +40,12 @@ class Sequence:
 
     def get_cover_percentage(self) -> float:
         return self.cover_percentage
+
+    def get_refseq_accession_number(self) -> str:
+        return self.refseq_accession_number
+
+    def get_organism_name(self) -> str:
+        return self.organism_name
+
+    def set_organism_name(self, organism_name):
+        self.organism_name = organism_name

--- a/src/Biocode/sequences/ThreePartRegionSequence.py
+++ b/src/Biocode/sequences/ThreePartRegionSequence.py
@@ -2,8 +2,9 @@ from src.Biocode.sequences.RegionSequence import RegionSequence
 
 
 class ThreePartRegionSequence(RegionSequence):
-    def __init__(self, sequence: str = None, sequence_data: dict = None, name: str = None):
-        super().__init__(sequence, sequence_data, 3, name)
+    def __init__(self, sequence: str = None, sequence_data: dict = None, name: str = None,
+                 refseq_accession_number: str = None, organism_name: str = None):
+        super().__init__(sequence, sequence_data, 3, name, refseq_accession_number, organism_name)
         super().calculate_regions()
 
     def set_regions_number(self, regions_number):

--- a/src/Biocode/services/RegionChromosomesService.py
+++ b/src/Biocode/services/RegionChromosomesService.py
@@ -5,6 +5,6 @@ from src.Biocode.services.services_context.all_services import Service
 class RegionChromosomesService(AbstractService):
     def __init__(self):
         self.table_name = "region_chromosomes"
-        self.columns = ["name", "organism_id", "cover_percentage", "cover", "regions_total", "region_number",
+        self.columns = ["name", "refseq_accession_number", "organism_id", "cover_percentage", "cover", "regions_total", "region_number",
                         "size", "whole_chromosome_id"]
         self.pk_column = "id"

--- a/src/Biocode/services/WholeChromosomesService.py
+++ b/src/Biocode/services/WholeChromosomesService.py
@@ -5,9 +5,16 @@ from src.Biocode.services.services_context.all_services import Service
 class WholeChromosomesService(AbstractService):
     def __init__(self):
         self.table_name = "whole_chromosomes"
-        self.columns = ["name", "organism_id", "cover_percentage", "cover", "size"]
+        self.columns = ["name", "refseq_accession_number", "organism_id", "cover_percentage", "cover", "size"]
         self.pk_column = "id"
 
 
-    def extract_by_name(self, name: str):
+    def extract_by_name(self, name: str) -> str:
         return self.extract_by_field(column="name", value=name)
+
+    def extract_by_refseq_accession_number(self, refseq_accession_number: str) -> str:
+        return self.extract_by_field(column="refseq_accession_number", value=refseq_accession_number)
+
+    def extract_id_by_refseq_accession_number(self, refseq_accession_number: str) -> int:
+        return int(self.extract_by_field(column="refseq_accession_number", value=refseq_accession_number).loc[0, 'id'])
+


### PR DESCRIPTION
…table and avoid using the hardcoded chromosome ID when loading a RM repeat

Solution implemented and cleaning some code, as arguments passing to functions, sequence name, refseq accession number and organism passing as arguments in functions in command.py and analyze.py files.

The goal was to try to extract that data from the Sequence object.

Refseq accession number is not being sent to region_chromosomes table.