### PR TITLE
ID-13.4: Graph the results of ID-13.3 for a whole organism

### DIFF
--- a/command.py
+++ b/command.py
@@ -6,7 +6,7 @@ from utils.logger import logger
 from analyze import load_organism, whole_MFA_genome, regions_MFA_genome, whole_MFA_sequence, regions_MFA_sequence, \
     find_kmers_recursively_in_genome, find_kmers_recursively_in_sequence
 from graph import load_data_whole, graph_whole, load_data_regions, graph_regions, graph_rm_results_from_file, \
-    graph_rm_results_from_database, graph_recursive_from_database
+    graph_rm_results_from_database, graph_recursive_from_database, graph_recursive_genome_from_database
 from download import remove_files, execute_download_command, clean_directory, uncompress_all_files
 from repeats import load_RM_repeats_from_file
 
@@ -70,13 +70,23 @@ def main():
                                       help="Enter the scientific name of the organism to use it as a folder name")
 
 
-    graph_recursive_parser = subparsers.add_parser('graph_recursive', help='Graph results found by Recursive algorith   m')
+    graph_recursive_parser = subparsers.add_parser('graph_recursive', help='Graph results found by Recursive algorithm')
     graph_recursive_parser.add_argument('-ran', help="Enter the refseq accession number of the sequence/chromosome")
     graph_recursive_parser.add_argument('--save', choices=['true', 'false'], default='true',
                                           help='Save graphs locally in /out directory')
     graph_recursive_parser.add_argument('-name',
                                           help="Enter the scientific name of the organism to use it as a folder name")
     graph_recursive_parser.add_argument('-n_max', help="(Optional) Graph only the top n largest values")
+
+    graph_recursive_genome_parser = subparsers.add_parser('graph_recursive_genome', help='Graph results found by '
+                                                                                         'Recursive algorithm in an organism')
+    graph_recursive_genome_parser.add_argument('-gcf', help="Enter the GCF id of the organism")
+    graph_recursive_genome_parser.add_argument('--save', choices=['true', 'false'], default='true',
+                                          help='Save graphs locally in /out directory')
+    graph_recursive_genome_parser.add_argument('-name',
+                                          help="Enter the scientific name of the organism to use it as a folder name")
+    graph_recursive_genome_parser.add_argument('-n_max', help="(Optional) Graph only the top n largest values per sequenec")
+
 
     download_parser = subparsers.add_parser('download', help='Download command')
     download_parser.add_argument('-name', help='Name or GCF for downloading')
@@ -104,6 +114,8 @@ def main():
         graph_rm_database_command(args)
     elif args.command == 'graph_recursive':
         graph_recursive_command(args)
+    elif args.command == 'graph_recursive_genome':
+        graph_recursive_genome_command(args)
     elif args.command == 'download':
         download_command(args)
     elif args.command == 'load_RM_repeats':
@@ -291,6 +303,13 @@ def graph_rm_database_command(args):
 def graph_recursive_command(args):
     try:
         graph_recursive_from_database(refseq_accession_number=args.ran, save=args.save, name=args.name, n_max=args.n_max)
+    except Exception as e:
+        logger.error(e)
+        traceback.print_exc()
+
+def graph_recursive_genome_command(args):
+    try:
+        graph_recursive_genome_from_database(GCF=args.gcf, save=args.save, name=args.name, n_max=args.n_max)
     except Exception as e:
         logger.error(e)
         traceback.print_exc()

--- a/graph.py
+++ b/graph.py
@@ -1,3 +1,4 @@
+from src.Biocode.services.OrganismsService import OrganismsService
 from src.Biocode.services.WholeResultsService import WholeResultsService
 from src.Biocode.services.RegionResultsService import RegionResultsService
 from src.Biocode.services.WholeChromosomesService import WholeChromosomesService
@@ -197,3 +198,12 @@ def graph_recursive_from_database(refseq_accession_number: str, save: bool, name
                                                     refseq_accession_number=refseq_accession_number)
     Graphs.graph_individual_plots_by_recursive_repeat_length(data, col="name", save=save, name=name,
                                                     refseq_accession_number=refseq_accession_number)
+@DBConnection
+@Timer
+def graph_recursive_genome_from_database(GCF: str, save: bool, name: str, n_max: int):
+    n_max = n_max and int(n_max)
+    organism_service = OrganismsService()
+    refseq_accession_numbers = organism_service.extract_chromosomes_refseq_accession_numbers_by_GCF(GCF)
+
+    for refseq_accession_number in refseq_accession_numbers:
+        graph_recursive_from_database(refseq_accession_number, save, name, n_max)

--- a/src/Biocode/managers/DBConnectionManager.py
+++ b/src/Biocode/managers/DBConnectionManager.py
@@ -17,6 +17,11 @@ class DBConnectionManager:
             DBConnectionManager.cursor = DBConnectionManager.conn.cursor()
         else:
             logger.warning("Database connection already started.")
+
+    @staticmethod
+    def is_connected():
+        return DBConnectionManager.conn is not None
+
     """
     Example usage:
     table_name = "organisms"

--- a/src/Biocode/services/OrganismsService.py
+++ b/src/Biocode/services/OrganismsService.py
@@ -2,6 +2,7 @@ from src.Biocode.managers.DBConnectionManager import DBConnectionManager
 from src.Biocode.services.AbstractService import AbstractService
 from src.Biocode.services.services_context.all_services import Service
 
+from typing import List
 
 @Service
 class OrganismsService(AbstractService):
@@ -13,3 +14,8 @@ class OrganismsService(AbstractService):
 
     def extract_by_GCF(self, GCF: str):
         return DBConnectionManager.extract_by_target(table_name=self.table_name, column="GCF", target=GCF)
+
+    def extract_chromosomes_refseq_accession_numbers_by_GCF(self, GCF: str) -> List:
+        query = f"SELECT refseq_accession_number FROM whole_chromosomes JOIN organisms o on whole_chromosomes.organism_id = o.id " \
+                f"WHERE GCF='{GCF}';"
+        return DBConnectionManager.extract_with_custom_query(query)['refseq_accession_number'].to_numpy()

--- a/src/Biocode/services/RecursiveRepeatsWholeChromosomesService.py
+++ b/src/Biocode/services/RecursiveRepeatsWholeChromosomesService.py
@@ -2,6 +2,8 @@ from src.Biocode.managers.DBConnectionManager import DBConnectionManager
 from src.Biocode.services.AbstractService import AbstractService
 from src.Biocode.services.services_context.all_services import Service
 
+from typing import List
+
 @Service
 class RecursiveRepeatsWholeChromosomesService(AbstractService):
     def __init__(self):
@@ -15,3 +17,5 @@ class RecursiveRepeatsWholeChromosomesService(AbstractService):
                 f"LEFT JOIN whole_chromosomes wc on rwc.whole_chromosomes_id = wc.id " \
                 f"WHERE refseq_accession_number='{refseq_accession_number}';"
         return DBConnectionManager.extract_with_custom_query(query)
+
+

--- a/utils/decorators.py
+++ b/utils/decorators.py
@@ -18,14 +18,25 @@ def Timer(func):
         return result
     return wrapper
 
+
 def DBConnection(func):
     def wrapper(*args, **kwargs):
-        DBConnectionManager.start()
-        logger.info(f"Database connection started")
-        func(*args, **kwargs)
-        DBConnectionManager.close()
-        logger.info(f"Database connection closed")
+        connection_started = False
+        if not DBConnectionManager.is_connected():
+            DBConnectionManager.start()
+            connection_started = True
+            logger.info("Database connection started")
+        try:
+            result = func(*args, **kwargs)
+        finally:
+            if connection_started:
+                DBConnectionManager.close()
+                logger.info("Database connection closed")
+
+        return result
+
     return wrapper
+
 
 def Singleton(cls):
     instances = {}


### PR DESCRIPTION
I have to graph the results of recursively found repeats that are stored in the database for a whole organism and create the command to execute it.

This is already implemented for a single sequence. The SQL query must be changed to search by organism instead of searching by refseq accession number. The "frequency" is taken from "largest_value" column from recursive_repeats_whole_chromosomes. This is not real frequency, but the largest values (peaks) in the CGR 3D graph.