### PR TITLE
ID-15: Distinguish real chromosome name from graph name

### DIFF
--- a/graph.py
+++ b/graph.py
@@ -116,34 +116,34 @@ def graph_rm_results_from_file(path: str, refseq_accession_number:str, partition
     DEFAULT_PARTITIONS = 300
     DEFAULT_REPEATS_LIMIT = 20
     whole_chromosomes_service = WholeChromosomesService()
-    size = whole_chromosomes_service.extract_size_by_refseq_accession_number(refseq_accession_number)
+    filename, size = whole_chromosomes_service.extract_filename_and_size_by_refseq_accession_number(refseq_accession_number)
     partitions = int(partitions) if isinstance(partitions, str) else DEFAULT_PARTITIONS
     regions = int(regions) if isinstance(regions, str) else DEFAULT_REGIONS
     plot_type = plot_type or "line"
 
     Graphs.graph_distribution_of_repeats_merged_from_file(path=path, size=size, partitions=partitions,
                                              legend=True, regions=regions, plot_type=plot_type, save=save,
-                                             name=name, refseq_accession_number=refseq_accession_number)
+                                             name=name, filename=filename)
 
 
     Graphs.graph_frequency_of_repeats_grouped_from_file(path, col="class_family", filtering=False, n_max=10, save=save,
-                                                        name=name, refseq_accession_number=refseq_accession_number)
+                                                        name=name, filename=filename)
     Graphs.graph_frequency_of_repeats_grouped_from_file(path, col="name", filtering=False, n_max=10, save=save, name=name,
-                                               refseq_accession_number=refseq_accession_number)
+                                                        filename=filename)
 
     Graphs.graph_distribution_of_repeats_from_file(path, col="class_family", legend=True, plot_type=plot_type,
                                                    limit=DEFAULT_REPEATS_LIMIT, regions=regions, save=save, name=name,
-                                                   refseq_accession_number=refseq_accession_number)
+                                                   filename=filename)
     Graphs.graph_distribution_of_repeats_from_file(path, col="name", legend=True, plot_type=plot_type,
                                                    limit=DEFAULT_REPEATS_LIMIT, regions=regions, save=save, name=name,
-                                                   refseq_accession_number=refseq_accession_number)
+                                                   filename=filename)
 
     Graphs.graph_distribution_of_repeats_subplots_from_file(path, col="class_family", legend=True,
                                                             limit=DEFAULT_REPEATS_LIMIT, regions=regions, save=save,
-                                                            name=name, refseq_accession_number=refseq_accession_number)
+                                                            name=name, filename=filename)
     Graphs.graph_distribution_of_repeats_subplots_from_file(path, col="name", legend=True,
                                                             limit=DEFAULT_REPEATS_LIMIT, regions=regions, save=save,
-                                                            name=name, refseq_accession_number=refseq_accession_number)
+                                                            name=name, filename=filename)
 
 
 @DBConnection
@@ -154,7 +154,7 @@ def graph_rm_results_from_database(refseq_accession_number:str, partitions:int, 
     DEFAULT_PARTITIONS = 300
     DEFAULT_REPEATS_LIMIT = 20
     whole_chromosomes_service = WholeChromosomesService()
-    size = whole_chromosomes_service.extract_size_by_refseq_accession_number(refseq_accession_number)
+    filename, size = whole_chromosomes_service.extract_filename_and_size_by_refseq_accession_number(refseq_accession_number)
     partitions = int(partitions) if isinstance(partitions, str) else DEFAULT_PARTITIONS
     regions = int(regions) if isinstance(regions, str) else DEFAULT_REGIONS
     plot_type = plot_type or "line"
@@ -165,27 +165,25 @@ def graph_rm_results_from_database(refseq_accession_number:str, partitions:int, 
 
     Graphs.graph_distribution_of_repeats_merged_from_database(data=data, size=size, partitions=partitions,
                                              legend=True, regions=regions, plot_type=plot_type, save=save,
-                                             name=name, refseq_accession_number=refseq_accession_number)
+                                             name=name, filename=filename)
 
     Graphs.graph_frequency_of_repeats_grouped_from_database(data, col="class_family", filtering=False, n_max=10, save=save,
-                                                        name=name, refseq_accession_number=refseq_accession_number)
-    Graphs.graph_frequency_of_repeats_grouped_from_database(data, col="name", filtering=False, n_max=10, save=save, name=name,
-                                               refseq_accession_number=refseq_accession_number)
+                                                        name=name, filename=filename)
+    Graphs.graph_frequency_of_repeats_grouped_from_database(data, col="name", filtering=False, n_max=10, save=save,
+                                                            name=name, filename=filename)
 
     Graphs.graph_distribution_of_repeats_from_database(data, col="class_family", legend=True, plot_type=plot_type,
-                                                   limit=20, regions=regions, save=save, name=name,
-                                                   refseq_accession_number=refseq_accession_number)
+                                                   limit=20, regions=regions, save=save, name=name, filename=filename)
     Graphs.graph_distribution_of_repeats_from_database(data, col="name", legend=True, plot_type=plot_type,
                                                        limit=20, regions=regions, save=save, name=name,
-                                                       refseq_accession_number=refseq_accession_number)
+                                                       filename=filename)
 
     Graphs.graph_distribution_of_repeats_subplots_from_database(data, col="class_family", legend=True,
                                                                 limit=DEFAULT_REPEATS_LIMIT, regions=regions, save=save,
-                                                                name=name,
-                                                                refseq_accession_number=refseq_accession_number)
+                                                                name=name,  filename=filename)
     Graphs.graph_distribution_of_repeats_subplots_from_database(data, col="name", legend=True,
                                                            limit=DEFAULT_REPEATS_LIMIT, regions=regions, save=save,
-                                                           name=name, refseq_accession_number=refseq_accession_number)
+                                                           name=name, filename=filename)
 
 
 @DBConnection
@@ -193,14 +191,14 @@ def graph_rm_results_from_database(refseq_accession_number:str, partitions:int, 
 def graph_recursive_from_database(refseq_accession_number: str, save: bool, name: str, n_max: int):
     n_max = n_max and int(n_max)
     recursive_repeats_whole_chromosomes_service = RecursiveRepeatsWholeChromosomesService()
-
+    whole_chromosomes_service = WholeChromosomesService()
+    filename = whole_chromosomes_service.extract_filename_by_refseq_accession_number(refseq_accession_number)
     data = recursive_repeats_whole_chromosomes_service.extract_info_by_chromosome(refseq_accession_number)
     Graphs.graph_recursive_repeats_largest_values_from_database(data, col="name", n_max=n_max, save=save, name=name,
-                                                                refseq_accession_number=refseq_accession_number)
-    Graphs.graph_grouped_by_recursive_repeat_length(data, col="name", save=save, name=name,
-                                                    refseq_accession_number=refseq_accession_number)
-    Graphs.graph_individual_plots_by_recursive_repeat_length(data, col="name", save=save, name=name,
-                                                    refseq_accession_number=refseq_accession_number)
+                                                                filename=filename)
+    Graphs.graph_grouped_by_recursive_repeat_length(data, col="name", save=save, name=name, filename=filename)
+    Graphs.graph_individual_plots_by_recursive_repeat_length(data, col="name", save=save, name=name, filename=filename)
+
 @DBConnection
 @Timer
 def graph_recursive_genome_from_database(GCF: str, save: bool, name: str, n_max: int):

--- a/src/Biocode/graphs/Graphs.py
+++ b/src/Biocode/graphs/Graphs.py
@@ -321,7 +321,7 @@ class Graphs:
         xticks_step = len(values) // divisions if len(values) // divisions > 0 else 1
         plt.xticks(range(0, len(values), xticks_step))
 
-        title = f"Coverage of the sequence {sequence_name}"
+        title = f"Coverage of the sequence {sequence_name} - {name}"
         plt.title(title)
         plt.xlabel('Representative percentage of the sequence')
         plt.ylabel('Absolute Value')
@@ -350,7 +350,7 @@ class Graphs:
             current_position += abs(negative)
 
         # Set labels and title
-        title = f"Coverage of the sequence {sequence_name}"
+        title = f"Coverage of the sequence {sequence_name} - {name}"
         ax.set_ylabel(title)
         ax.set_title('Order (bottom-up)')
 
@@ -389,7 +389,7 @@ class Graphs:
                          f"q = {fq_value['q']}", va='center', ha='left', fontsize=5)
                 plt.legend(bbox_to_anchor=(1.05, 1), loc=2, borderaxespad=0., ncol=2)
 
-        title = f"fq vs ln(ε) for {sequence_name}"
+        title = f"fq vs ln(ε) for {sequence_name} - {name}"
         plt.title(title)
         if save:
             Graphs._savefig(title, name)
@@ -413,7 +413,7 @@ class Graphs:
         plt.xlabel('Log(Epsilons)')
         plt.ylabel('fq')
         plt.legend()
-        title = f"linear regression for {sequence_name}"
+        title = f"linear regression for {sequence_name} - {name}"
         if save:
             Graphs._savefig(title, name)
 
@@ -439,22 +439,22 @@ class Graphs:
     def graph_distribution_of_repeats_merged_from_database(data: pd.DataFrame, size: int, partitions: int = 300,
                                                        filter_string: str = None, filter_column: str = None,
                                                        legend: bool = True, regions: int = 3, save: bool=True,
-                                                       name: str = None, refseq_accession_number: str = None,
+                                                       name: str = None, filename: str = None,
                                                        plot_type: str = "line"):
         Graphs._graph_distribution_of_repeats_merged(data, size, partitions, filter_string,
                                                      filter_column, legend, regions, plot_type, save, name,
-                                                     refseq_accession_number)
+                                                     filename)
 
     @staticmethod
     def graph_distribution_of_repeats_merged_from_file(path: str, size: int, partitions: int = 300,
                                              filter_string: str = None,
                                              filter_column: str = None, legend: bool = True, regions: int = 3,
                                              plot_type: str = "line", save: bool=True, name: str = None,
-                                             refseq_accession_number: str = None):
+                                             filename: str = None):
         df = Graphs._import_file_out(path)
         Graphs._graph_distribution_of_repeats_merged(df, size, partitions, filter_string,
                                                      filter_column, legend, regions, plot_type, save, name,
-                                                     refseq_accession_number)
+                                                     filename)
 
 
     @staticmethod
@@ -462,7 +462,7 @@ class Graphs:
                                               filter_string: str = None,
                                               filter_column: str = None, legend: bool = True, regions: int = 3,
                                               plot_type: str = "line", save: bool=True, name: str=None,
-                                              refseq_accession_number: str=None):
+                                              filename: str=None):
         if filter_string:
             df = Graphs._filter(df, filter_string, filter_column)
 
@@ -481,7 +481,7 @@ class Graphs:
             for i, repeat_sum in enumerate(repeat_lengths):
                 plt.bar(i, repeat_sum, color='gray')
 
-        title = f"Distribution of Repeats Across Sequence {refseq_accession_number}"
+        title = f"Distribution of Repeats across Sequence {filename} - {name}"
         plt.ylabel("Length of Repeat (bp)")
         plt.xlabel("Repeat")
         plt.title(title)
@@ -529,26 +529,26 @@ class Graphs:
     @staticmethod
     def graph_frequency_of_repeats_grouped_from_database(data, col=None, filtering=False, filter_string=None,
                                                      filter_column=None, n_max=10, save: bool = True, name: str = None,
-                                                     refseq_accession_number: str = None):
+                                                     filename: str = None):
         Graphs._graph_frequency_of_repeats_grouped(data, col, filtering, filter_string, filter_column, n_max, save,
-                                                   name, refseq_accession_number)
+                                                   name, filename)
 
     @staticmethod
     def graph_frequency_of_repeats_grouped_from_file(path, col=None, filtering=False, filter_string=None,
                                               filter_column=None, n_max=10, save: bool=True, name: str=None,
-                                              refseq_accession_number: str=None):
+                                              filename: str=None):
         data = Graphs._import_file_out(path)
         Graphs._graph_frequency_of_repeats_grouped(data, col, filtering, filter_string, filter_column, n_max, save,
-                                                   name, refseq_accession_number)
+                                                   name, filename)
 
     @staticmethod
     def _graph_frequency_of_repeats_grouped(data, col=None, filtering=False, filter_string=None,
                                             filter_column=None, n_max=10, save: bool=True, name: str=None,
-                                            refseq_accession_number: str=None):
+                                            filename: str=None):
         grouped_data_sorted = Graphs._group_columns(data, col, filtering, filter_string, filter_column)
         grouped_data_sorted = grouped_data_sorted.head(n_max)
 
-        title = f"Frequency of Repeats {col} Across Sequence {refseq_accession_number} by {col}"
+        title = f"Frequency of Repeats {col} Across Sequence {filename} by {col} - {name}"
         # Plot the distribution of repeats for each class/family
         plt.figure(figsize=(10, 6))
         plt.bar(grouped_data_sorted[col], grouped_data_sorted["repeat_length"])
@@ -574,23 +574,23 @@ class Graphs:
 
     @staticmethod
     def graph_distribution_of_repeats_from_file(path, col, legend, plot_type, limit, regions, save, name,
-                                                refseq_accession_number):
+                                                filename):
         data = Graphs._import_file_out(path)
         grouped_data_sorted = Graphs._group_columns(data, col)
         Graphs._graph_distribution_of_repeats(data, grouped_data_sorted, col, legend, plot_type, limit, regions,
-                                              save, name, refseq_accession_number)
+                                              save, name, filename)
 
     @staticmethod
     def graph_distribution_of_repeats_from_database(data, col, legend, plot_type, limit, regions, save, name,
-                                                refseq_accession_number):
+                                                filename):
         grouped_data_sorted = Graphs._group_columns(data, col)
         Graphs._graph_distribution_of_repeats(data, grouped_data_sorted, col, legend, plot_type, limit, regions,
-                                              save, name, refseq_accession_number)
+                                              save, name, filename)
 
 
     @staticmethod
     def _graph_distribution_of_repeats(df, grouped_data_sorted, col, legend=True, plot_type="line", limit=20,
-                                       regions=3, save=True, name=None, refseq_accession_number=None):
+                                       regions=3, save=True, name=None, filename=None):
         if df.empty or grouped_data_sorted.empty:
             logger.warning("Empty DataFrame provided for Distribution of repeats graph; skipping plot.")
             return
@@ -629,7 +629,7 @@ class Graphs:
                                  row['name'] + " - " + row['class_family']]  # Update the maximum value
                     plotted = True
 
-        title = f"Distribution of Repeats Across Sequence {refseq_accession_number} by {col}"
+        title = f"Distribution of Repeats Across Sequence {filename} by {col} - {name}"
         plt.ylabel("Length of Repeat (bp)")
         plt.xlabel("Repeat")
         plt.title(title)
@@ -655,25 +655,25 @@ class Graphs:
 
     @staticmethod
     def graph_distribution_of_repeats_subplots_from_file(path, col="class_family", legend=True, limit=20, regions=3,
-                                               shared_y_axis=False, save=True, name=None, refseq_accession_number=None):
+                                               shared_y_axis=False, save=True, name=None, filename=None):
         data = Graphs._import_file_out(path)
         grouped_data_sorted = Graphs._group_columns(data, col)
         Graphs._graph_distribution_of_repeats_subplots(data, grouped_data_sorted, col, legend, limit, regions,
-                                                       shared_y_axis, save, name, refseq_accession_number)
+                                                       shared_y_axis, save, name, filename)
 
     @staticmethod
     def graph_distribution_of_repeats_subplots_from_database(data, col="class_family", legend=True, limit=20, regions=3,
                                                              shared_y_axis=False, save=None, name=None,
-                                                            refseq_accession_number=None):
+                                                            filename=None):
         grouped_data_sorted = Graphs._group_columns(data, col)
         Graphs._graph_distribution_of_repeats_subplots(data, grouped_data_sorted, col, legend, limit, regions,
-                                                       shared_y_axis, save, name, refseq_accession_number)
+                                                       shared_y_axis, save, name, filename)
 
 
     @staticmethod
     def _graph_distribution_of_repeats_subplots(df, grouped_data_sorted, col="class_family", legend=True, limit=20,
                                                 regions=3, shared_y_axis=False, save=True, name=None,
-                                                refseq_accession_number=None):
+                                                filename=None):
         # Extract unique class/family values
         unique_class_family = grouped_data_sorted.head(limit)[col].tolist()
 
@@ -698,7 +698,7 @@ class Graphs:
             ax.plot(repeat_lengths, color=color_dict.get(label), label=label)
             ax.set_ylabel("Length of Repeat (bp)")
             ax.set_xlabel("Repeat")
-            ax.set_title(f"Distribution of {label} repeats across Sequence {refseq_accession_number}")
+            ax.set_title(f"Distribution of {label} repeats across Sequence {filename} - {name}")
             ax.grid(axis='y', linestyle='--', alpha=0.7)
             ax.set_ylim(0, np.max(repeat_lengths) * 1.1)  # Set the y-axis limit to 110% of the maximum value graphed
 
@@ -718,7 +718,7 @@ class Graphs:
                 ax.set_ylim(0, max_y)
 
         plt.tight_layout()
-        title = f"Distribution of repeats across Sequence {refseq_accession_number} by {col}"
+        title = f"Distribution of repeats across Sequence {filename} by {col}"
         if save:
             Graphs._savefig(title, f"{name}/repeats/RM/distribution_subplots")
         plt.show()
@@ -726,7 +726,7 @@ class Graphs:
 
     @staticmethod
     def graph_recursive_repeats_largest_values_from_database(df, col=None, n_max=None, save=True, name=None,
-                                                refseq_accession_number=None):
+                                                filename=None):
         df = df.sort_values(by='largest_value', ascending=False)
         if n_max is not None:
             df = df.head(n_max)
@@ -734,7 +734,7 @@ class Graphs:
         plt.figure(figsize=(10, 6))
         plt.bar(df[col], df['largest_value'], color='blue')
 
-        title = f"Recursively found repeats - largest values in Sequence {refseq_accession_number}"
+        title = f"Recursively found repeats - largest values in Sequence {filename} - {name}"
         plt.xlabel('Sequence')
         plt.ylabel('Largest Value')
         plt.title(title)
@@ -746,7 +746,7 @@ class Graphs:
         plt.show()
 
     @staticmethod
-    def graph_grouped_by_recursive_repeat_length(df, col=None, save=True, name=None, refseq_accession_number=None):
+    def graph_grouped_by_recursive_repeat_length(df, col=None, save=True, name=None, filename=None):
         grouped = df.groupby('repeat_length')
 
         plt.figure(figsize=(14, 8))
@@ -755,7 +755,7 @@ class Graphs:
             group = group.sort_values(by='largest_value', ascending=False)
             plt.bar(group[col], group['largest_value'], label=f'Repeat Length: {repeat_length}')
 
-        title = f"Largest Values Grouped by Repeat Length of Sequence {refseq_accession_number}"
+        title = f"Largest Values Grouped by Repeat Length of Sequence {filename} - {name}"
         plt.xlabel('Sequence')
         plt.ylabel('Largest Value')
         plt.title(title)
@@ -769,7 +769,7 @@ class Graphs:
 
     @staticmethod
     def graph_individual_plots_by_recursive_repeat_length(df, col=None, save=True, name=None,
-                                                          refseq_accession_number=None):
+                                                          filename=None):
         grouped = df.groupby('repeat_length')
 
         for repeat_length, group in grouped:
@@ -778,7 +778,7 @@ class Graphs:
             plt.figure(figsize=(10, 6))
             plt.bar(group_sorted[col], group_sorted['largest_value'], color='blue')
 
-            title = f"Largest Values for Repeat Length {repeat_length} of Sequence {refseq_accession_number}"
+            title = f"Largest Values for Repeat Length {repeat_length} of Sequence {filename} - {name}"
             plt.xlabel('Sequence')
             plt.ylabel('Largest Value')
             plt.title(title)
@@ -787,7 +787,7 @@ class Graphs:
             plt.tight_layout()
 
             if save:
-                filename = f"{name}/repeats/recursive/repeat_length_{repeat_length}"
-                Graphs._savefig(title, filename)
+                route = f"{name}/repeats/recursive/repeat_length_{repeat_length}"
+                Graphs._savefig(title, route)
             plt.show()
 

--- a/src/Biocode/services/WholeChromosomesService.py
+++ b/src/Biocode/services/WholeChromosomesService.py
@@ -1,6 +1,8 @@
 from src.Biocode.services.AbstractService import AbstractService
 from src.Biocode.services.services_context.all_services import Service
 
+from typing import Tuple
+
 @Service
 class WholeChromosomesService(AbstractService):
     def __init__(self):
@@ -20,3 +22,10 @@ class WholeChromosomesService(AbstractService):
 
     def extract_size_by_refseq_accession_number(self, refseq_accession_number: str) -> int:
         return int(self.extract_by_field(column="refseq_accession_number", value=refseq_accession_number).loc[0, 'size'])
+
+    def extract_filename_by_refseq_accession_number(self, refseq_accession_number: str) -> str:
+        return self.extract_by_field(column="refseq_accession_number", value=refseq_accession_number).loc[0, 'name']
+
+    def extract_filename_and_size_by_refseq_accession_number(self, refseq_accession_number: str) -> Tuple[str, int]:
+        row = self.extract_by_field(column="refseq_accession_number", value=refseq_accession_number)
+        return row.loc[0, 'name'], int(row.loc[0, 'size'])


### PR DESCRIPTION
I need to use refseq accession number as an identifier of sequences in the database, but in every graph, the filename must be used plus the organism name, instead of the refseq accession number.