### PR TITLE
ID-27: [Refactor] Stop using .loc in sequence managers when extractin…

### DIFF
--- a/graph.py
+++ b/graph.py
@@ -272,7 +272,7 @@ def _graph_gtf_single_chromosome_from_database(refseq_accession_number: str, nam
     logger.info(f"Graphing for the sequence {refseq_accession_number}")
     chromosome_name, size = whole_chromosomes_service.extract_filename_and_size_by_refseq_accession_number(
                                 refseq_accession_number)
-    df = gtf_genes_service.extract_genes_by_chromosome(refseq_accession_number)
+    df = gtf_genes_service. extract_genes_by_chromosome(refseq_accession_number)
 
     Graphs.graph_distribution_of_genes_merged(df, name, size, partitions, regions, plot_type, chromosome_name,
                                               bool(save))

--- a/src/Biocode/managers/GenomeManager.py
+++ b/src/Biocode/managers/GenomeManager.py
@@ -94,7 +94,7 @@ class GenomeManager(GenomeManagerInterface):
         ["chromosome_id", "Dq_values", "tau_q_values", "DDq"]
         [{"q_values", "Dq_values", "tau_q_values", "DDq"}]
         """
-        organism_id = int(self.organisms_service.extract_by_GCF(GCF=GCF).loc[0, 'id'])
+        organism_id = self.organisms_service.extract_by_GCF(GCF=GCF)
 
         for index, result in enumerate(self.mfa_results):
             chromosome_id = self.whole_chromosomes_service.insert(record=(result['sequence_name'],

--- a/src/Biocode/managers/RegionGenomeManager.py
+++ b/src/Biocode/managers/RegionGenomeManager.py
@@ -143,7 +143,7 @@ class RegionGenomeManager(GenomeManagerInterface):
         [{"q_values", "Dq_values", "tau_q_values", "DDq"}]
         
         """
-        organism_id = int(self.organisms_service.extract_by_GCF(GCF=GCF).loc[0, 'id'])
+        organism_id = self.organisms_service.extract_by_GCF(GCF=GCF)
         for index, result in enumerate(self.flattened_mfa_results):
             region_number = (index % self.regions_number) + 1
             chromosome_id = self.region_chromosomes_service.insert(record=(result['sequence_name'], organism_id,

--- a/src/Biocode/managers/RegionSequenceManager.py
+++ b/src/Biocode/managers/RegionSequenceManager.py
@@ -189,7 +189,7 @@ class RegionSequenceManager(SequenceManagerInterface):
         """
         #try:
 
-        organism_id = int(self.organisms_service.extract_by_GCF(GCF=GCF).loc[0, 'id'])
+        organism_id = self.organisms_service.extract_by_GCF(GCF=GCF)
         whole_chromosome_id = int(self.whole_chromosomes_service.extract_id_by_refseq_accession_number(
             self.sequence.get_refseq_accession_number()))
 

--- a/src/Biocode/managers/SequenceManager.py
+++ b/src/Biocode/managers/SequenceManager.py
@@ -169,7 +169,7 @@ class SequenceManager(SequenceManagerInterface):
         ["chromosome_id", "Dq_values", "tau_q_values", "DDq"]
         [{"q_values", "Dq_values", "tau_q_values", "DDq"}]
         """
-        self.organism_id = int(self.organisms_service.extract_by_GCF(GCF=GCF).loc[0, 'id'])
+        self.organism_id = self.organisms_service.extract_by_GCF(GCF=GCF)
 
         self.chromosome_id = self._insert_mfa_results_to_whole_chromosomes_table()
         self.whole_results_service.insert(record=(self.chromosome_id, list_to_str(self.mfa_results['Dq_values'].tolist()),
@@ -187,7 +187,7 @@ class SequenceManager(SequenceManagerInterface):
     def save_repeats_found_recursively_to_db(self, kmers_list: List[MiGridCoordinatesValuesAndNucleotides], GCF: str,
                                              method_to_find_it: str = "Recursively"):
 
-        self.organism_id = int(self.organisms_service.extract_by_GCF(GCF=GCF).loc[0, 'id'])
+        self.organism_id = self.organisms_service.extract_by_GCF(GCF=GCF)
 
         self.chromosome_id = self._insert_mfa_results_to_whole_chromosomes_table()
 

--- a/src/Biocode/services/OrganismsService.py
+++ b/src/Biocode/services/OrganismsService.py
@@ -13,7 +13,7 @@ class OrganismsService(AbstractService):
         self.pk_column = "id"
 
     def extract_by_GCF(self, GCF: str):
-        return self.extract_by_field(column="GCF", value=GCF)
+        return int(self.extract_by_field(column="GCF", value=GCF).loc[0, 'id'])
 
     def extract_chromosomes_refseq_accession_numbers_by_GCF(self, GCF: str) -> List:
         query = f"SELECT refseq_accession_number FROM whole_chromosomes JOIN organisms o on whole_chromosomes.organism_id = o.id " \


### PR DESCRIPTION
…g from rows

Pass the .loc call to the service classes. Only service classes must call this Pandas method.