### PR TITLE
ID-28: [Refactor][MFA] Refactor the MFA analysis so that the mi_grids…

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,15 @@ The organism name and GCF expressed in that file are the ones to be used in the 
 Download and uncompress files
 
         py .\command.py download -name "caenorhabditis elegans"
-        py .\command.py download -name GCF_000002985_4
+        py .\command.py download -name GCF_000002985_6
 
 ### Analyze
 Analyze and load the organism and genome data. 
 
                     
         py .\command.py analyze_genome -name "caenorhabditis elegans" -mode regions
-        py .\command.py analyze_genome -name GCF_000002985_4 -mode regions
-        py .\command.py analyze_genome -name GCF_000002985_4 -mode whole
+        py .\command.py analyze_genome -name GCF_000002985_6 -mode regions
+        py .\command.py analyze_genome -name GCF_000002985_6 -mode whole
 
 Analyze only one sequence file (one chromosome) given a file path
     

--- a/analyze.py
+++ b/analyze.py
@@ -28,7 +28,16 @@ def whole_MFA_genome(organism_name, gcf, data, save_to_db):
     genome_manager.calculate_multifractal_analysis_values(GCF=gcf, save_to_db=save_to_db)
     #genome_manager.save_to_db_after_execution(GCF=gcf)
     #genome_manager.graph_linear_fit()
-    # genome_manager.generate_df_results()
+    #genome_manager.generate_df_results()
+
+@DBConnection
+@Timer
+def whole_MFA_sequence(gcf, sequence, save_to_db):
+    sequence_manager = SequenceManager(sequence=sequence)
+    sequence_manager.calculate_multifractal_analysis_values(gcf)
+
+    if save_to_db:
+        sequence_manager.save_results_to_db_during_execution(GCF=gcf)
 
 @DBConnection
 @Timer
@@ -38,20 +47,13 @@ def find_kmers_recursively_in_genome(organism_name, gcf, data, save_to_db):
         GCF=gcf, save_to_db=save_to_db, method_to_find_it="Recursively")
 
 
-@DBConnection
-@Timer
-def whole_MFA_sequence(gcf, sequence, save_to_db):
-    sequence_manager = SequenceManager(sequence=sequence)
-    sequence_manager.calculate_multifractal_analysis_values()
 
-    if save_to_db:
-        sequence_manager.save_to_db_during_execution(GCF=gcf)
 
 @DBConnection
 @Timer
 def find_kmers_recursively_in_sequence(gcf, sequence, save_to_db):
     sequence_manager = SequenceManager(sequence=sequence)
-    sequence_manager.calculate_multifractal_analysis_values()
+    sequence_manager.calculate_multifractal_analysis_values(gcf)
     kmers_list = sequence_manager.find_only_kmers_recursively()
     if save_to_db:
         sequence_manager.save_repeats_found_recursively_to_db(
@@ -72,8 +74,8 @@ def regions_MFA_genome(organism_name, gcf, data, regions_number, save_to_db):
 def regions_MFA_sequence(gcf, sequence, regions_number, save_to_db):
 
     region_sequence_manager = RegionSequenceManager(sequence=sequence, regions_number=regions_number)
-    region_sequence_manager.calculate_multifractal_analysis_values()
+    region_sequence_manager.calculate_multifractal_analysis_values(gcf)
 
     if save_to_db:
-        region_sequence_manager.save_to_db_during_execution(GCF=gcf)
+        region_sequence_manager.save_results_to_db_during_execution(GCF=gcf)
 

--- a/resources/db_config.yaml
+++ b/resources/db_config.yaml
@@ -1,5 +1,5 @@
 database:
-  type: "postgresql"  # other options: "postgresql", "mysql"
+  type: "sqlite"  # other options: "postgresql", "mysql"
   sqlite:
     db_file: "resources/MFA_analysis.db"
   postgresql:

--- a/resources/schema_mysql.sql
+++ b/resources/schema_mysql.sql
@@ -35,13 +35,23 @@ CREATE TABLE region_chromosomes (
 );
 
 -- Create mi_grids table with foreign key constraint
-CREATE TABLE mi_grids (
+CREATE TABLE whole_mi_grids (
   id INT AUTO_INCREMENT PRIMARY KEY,
   mi_grid LONGBLOB,
-  chromosome_id INT,
+  whole_chromosome_id INT,
   epsilon_size FLOAT,
-  FOREIGN KEY (chromosome_id) REFERENCES region_chromosomes(id)
+  FOREIGN KEY (whole_chromosome_id) REFERENCES whole_chromosomes(id)
 );
+
+-- Create mi_grids table with foreign key constraint
+CREATE TABLE region_mi_grids (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  mi_grid LONGBLOB,
+  region_chromosome_id INT,
+  epsilon_size FLOAT,
+  FOREIGN KEY (region_chromosome_id) REFERENCES region_chromosomes(id)
+);
+
 
 -- Create chr_whole_results table with foreign key constraint
 CREATE TABLE chr_whole_results (

--- a/resources/schema_postgresql.sql
+++ b/resources/schema_postgresql.sql
@@ -32,10 +32,18 @@ CREATE TABLE region_chromosomes (
 );
 
 -- Create mi_grids table with foreign key constraint
-CREATE TABLE mi_grids (
+CREATE TABLE whole_mi_grids (
   id SERIAL PRIMARY KEY,
   mi_grid BYTEA,
-  chromosome_id INTEGER REFERENCES whole_chromosomes(id),
+  whole_chromosome_id INTEGER REFERENCES whole_chromosomes(id),
+  epsilon_size REAL
+);
+
+-- Create mi_grids table with foreign key constraint
+CREATE TABLE region_mi_grids (
+  id SERIAL PRIMARY KEY,
+  mi_grid BYTEA,
+  region_chromosome_id INTEGER REFERENCES region_chromosomes(id),
   epsilon_size REAL
 );
 

--- a/resources/schema_sqlite.sql
+++ b/resources/schema_sqlite.sql
@@ -31,10 +31,18 @@ CREATE TABLE region_chromosomes (
 );
 
 -- Create mi_grids table with foreign key constraint
-CREATE TABLE mi_grids (
+CREATE TABLE whole_mi_grids (
   id INTEGER PRIMARY KEY,
   mi_grid BLOB,
-  chromosome_id INTEGER REFERENCES chromosomes(id),
+  whole_chromosome_id INTEGER REFERENCES whole_chromosomes(id),
+  epsilon_size REAL
+);
+
+-- Create mi_grids table with foreign key constraint
+CREATE TABLE region_mi_grids (
+  id INTEGER PRIMARY KEY,
+  mi_grid BLOB,
+  region_chromosome_id INTEGER REFERENCES region_chromosomes(id),
   epsilon_size REAL
 );
 

--- a/src/Biocode/managers/DBConnectionManager.py
+++ b/src/Biocode/managers/DBConnectionManager.py
@@ -57,7 +57,8 @@ class DBConnectionManager:
         return DBConnectionManager.conn is not None
 
     @staticmethod
-    def insert(table_name, columns: list, pk, record: tuple):
+    def _get_placeholder_and_conversion():
+        """Get the SQL placeholder and field conversion logic based on the database type."""
         if DBConnectionManager.is_sqlite:
             placeholder = "?"
             array_conversion = lambda x: x if not isinstance(x, list) else str(x)
@@ -70,37 +71,77 @@ class DBConnectionManager:
         else:
             raise ValueError("Unsupported database type")
 
-        converted_record = tuple(array_conversion(field) for field in record)
+        return placeholder, array_conversion
 
-        check_query = f'SELECT * FROM {table_name} WHERE {" AND ".join([f"{col} = {placeholder}" for col in columns if col != pk])};'
-
-
+    @staticmethod
+    def _execute_query(query: str, record: tuple, return_last_id: bool = False, pk: str = None):
+        """Executes the provided query with the given record and returns the last inserted ID if requested."""
         try:
-            DBConnectionManager.cursor.execute(check_query, converted_record)
-            existing_record = DBConnectionManager.cursor.fetchone()
+            DBConnectionManager.cursor.execute(query, record)
+            DBConnectionManager.conn.commit()
 
-            if existing_record:
-                existing_record_id = existing_record[0]
-                logger.info(f"Existing record with id {existing_record_id} in table {table_name}")
-                return existing_record_id
-            else:
-                insert_query = f'INSERT INTO {table_name} ({", ".join(columns)}) VALUES ({", ".join([placeholder] * len(columns))})'
-
+            if return_last_id:
                 if DBConnectionManager.is_postgresql:
-                    insert_query += f' RETURNING {pk};'
-
-                DBConnectionManager.cursor.execute(insert_query, converted_record)
-                DBConnectionManager.conn.commit()
-                logger.info(f"Inserted in table {table_name} - row {converted_record}")
-                if DBConnectionManager.is_postgresql:
-                    last_inserted_id = DBConnectionManager.cursor.fetchone()[0]
+                    return DBConnectionManager.cursor.fetchone()[0]
                 elif DBConnectionManager.is_sqlite or DBConnectionManager.is_mysql:
-                    last_inserted_id = DBConnectionManager.cursor.lastrowid
+                    return DBConnectionManager.cursor.lastrowid
 
-                return last_inserted_id
         except Exception as e:
             logger.error(f"Error executing query: {e}")
             raise
+
+    @staticmethod
+    def insert(table_name, columns: list, pk, record: tuple):
+        # Get placeholder and conversion logic
+        placeholder, array_conversion = DBConnectionManager._get_placeholder_and_conversion()
+
+        # Convert the record fields (handling lists/arrays if necessary)
+        converted_record = tuple(array_conversion(field) for field in record)
+
+        # Build and execute check query to find existing record
+        check_query = f'SELECT * FROM {table_name} WHERE {" AND ".join([f"{col} = {placeholder}" for col in columns if col != pk])};'
+        DBConnectionManager.cursor.execute(check_query, converted_record)
+        existing_record = DBConnectionManager.cursor.fetchone()
+
+        if existing_record:
+            existing_record_id = existing_record[0]
+            logger.info(f"Existing record with id {existing_record_id} in table {table_name}")
+            return existing_record_id
+
+        # Build the insert query
+        insert_query = f'INSERT INTO {table_name} ({", ".join(columns)}) VALUES ({", ".join([placeholder] * len(columns))})'
+        if DBConnectionManager.is_postgresql:
+            insert_query += f' RETURNING {pk};'
+
+        # Execute the insert query and return the last inserted ID
+        return DBConnectionManager._execute_query(insert_query, converted_record, return_last_id=True, pk=pk)
+
+    @staticmethod
+    def update(table_name, columns: list, pk_col, pk_value, record: tuple):
+        placeholder, array_conversion = DBConnectionManager._get_placeholder_and_conversion()
+        converted_record = tuple(array_conversion(field) for field in record)
+        update_query = f'UPDATE {table_name} SET {", ".join([f"{col} = {placeholder}" for col in columns if col != pk_col])} WHERE {pk_col} = {pk_value};'
+        logger.info(f"Updating row in table {table_name} with {pk_col} = {pk_value}")
+        return DBConnectionManager._execute_query(update_query, converted_record)
+
+
+    @staticmethod
+    def update_when_null(table_name, columns: list, pk_col, pk_value, record: tuple):
+        placeholder, array_conversion = DBConnectionManager._get_placeholder_and_conversion()
+        converted_record = tuple(array_conversion(field) for field in record)
+        null_check_query = f"SELECT * FROM {table_name} WHERE {pk_col} = {placeholder} AND ({' OR '.join([f'{col} IS NULL' for col in columns])});"
+        DBConnectionManager._execute_query(null_check_query, (pk_value,))
+        row_with_nulls = DBConnectionManager.cursor.fetchone()  # Fetch one row with NULL values
+
+        # If there is at least one row with a NULL value, proceed with the update
+        if row_with_nulls:
+            update_query = f'UPDATE {table_name} SET {", ".join([f"{col} = {placeholder}" for col in columns if col != pk_col])} WHERE {pk_col} = {pk_value};'
+            logger.debug(update_query)
+            logger.info(f"Updating row in table {table_name} with {pk_col} = {pk_value} where NULL values existed")
+            return DBConnectionManager._execute_query(update_query, converted_record)
+        else:
+            logger.info(
+                f"No NULL values found for row with {pk_col} = {pk_value} in table {table_name}. Update not performed.")
 
     @staticmethod
     def extract_all(table_name):
@@ -117,22 +158,25 @@ class DBConnectionManager:
 
     @staticmethod
     def extract_by_target(table_name, column, target):
-        # Determine the correct placeholder for the current database
-        if DBConnectionManager.is_sqlite:
-            placeholder = "?"
-        else:
-            placeholder = "%s"
+        try:
+            # Determine the correct placeholder for the current database
+            if DBConnectionManager.is_sqlite:
+                placeholder = "?"
+            else:
+                placeholder = "%s"
 
-        query = f"SELECT * FROM {table_name} WHERE {column} = {placeholder};"
-        DBConnectionManager.cursor.execute(query, (target,))
-        rows = DBConnectionManager.cursor.fetchall()
+            query = f"SELECT * FROM {table_name} WHERE {column} = {placeholder};"
+            DBConnectionManager.cursor.execute(query, (target,))
+            rows = DBConnectionManager.cursor.fetchall()
+            if not rows:
+                return None
 
-        if not rows:
-            return None
-
-        columns = [col[0] for col in DBConnectionManager.cursor.description]
-        df = pd.DataFrame(rows, columns=columns)
-        return df
+            columns = [col[0] for col in DBConnectionManager.cursor.description]
+            df = pd.DataFrame(rows, columns=columns)
+            return df
+        except Exception as e:
+            logger.error(f"Error executing query for {target} in {table_name}: {e}")
+            raise
 
     @staticmethod
     def extract_with_custom_query(query):

--- a/src/Biocode/managers/GenomeManagerInterface.py
+++ b/src/Biocode/managers/GenomeManagerInterface.py
@@ -88,30 +88,31 @@ class GenomeManagerInterface:
         """Graph t(q) vs q"""
         pass
 
-        def calculate_multifractal_analysis_values(self, GCF: str, save_to_db: bool):
-            """Generate mfa generators, generate mfa values, the cover and cover
-            percentage and send them to the DB"""
-            for manager in self.managers:
-                logger.info(f"Starting chromosome: {manager.get_sequence_name()}")
-                manager.calculate_multifractal_analysis_values()
-                if save_to_db:
-                    manager.save_to_db_during_execution(GCF=GCF)
-                del manager
-                gc.collect()
+    def calculate_multifractal_analysis_values(self, GCF: str, save_to_db: bool):
+        """Generate mfa generators, generate mfa values, the cover and cover
+        percentage and send them to the DB"""
+        for manager in self.managers:
+            logger.info(f"Starting chromosome: {manager.get_sequence_name()}")
+            manager.calculate_multifractal_analysis_values(GCF)
+            if save_to_db:
+                manager.save_results_to_db_during_execution(GCF=GCF)
+                logger.info(f"Saved results for GCF: {GCF}")
+            del manager
+            gc.collect()
 
-            """
-            self.n_largest_mi_grid_values_strings = self._find_nucleotides_strings_recursively(
-                manager=manager, k1=10, k2=4, k_step=-1, amount_sequences=10
-            )
-            logger.critical(self.n_largest_mi_grid_values_strings)
-            
-            """
+        """
+        self.n_largest_mi_grid_values_strings = self._find_nucleotides_strings_recursively(
+            manager=manager, k1=10, k2=4, k_step=-1, amount_sequences=10
+        )
+        logger.critical(self.n_largest_mi_grid_values_strings)
+        
+        """
 
 
     def find_only_kmers_recursively_and_calculate_multifractal_analysis_values(self, GCF: str, save_to_db: bool,
                                                                                method_to_find_it: str):
         for manager in self.managers:
-            manager.calculate_multifractal_analysis_values()
+            manager.calculate_multifractal_analysis_values(GCF)
             kmers_list = self._find_nucleotides_strings_recursively(manager, k1=10, k2=4, k_step=-1,
                                                                     amount_sequences=10)
             if save_to_db:

--- a/src/Biocode/managers/RegionSequenceManager.py
+++ b/src/Biocode/managers/RegionSequenceManager.py
@@ -180,7 +180,7 @@ class RegionSequenceManager(SequenceManagerInterface):
     def get_managers(self) -> list[SequenceManager]:
         return self.managers
 
-    def save_to_db_during_execution(self, GCF):
+    def save_results_to_db_during_execution(self, GCF):
         """
         [(val1, val2), (val1, val2)]
         ["chromosome_id", "Dq_values", "tau_q_values", "DDq"]

--- a/src/Biocode/managers/SequenceManagerInterface.py
+++ b/src/Biocode/managers/SequenceManagerInterface.py
@@ -38,10 +38,10 @@ class SequenceManagerInterface:
         """Attach to the fields of the class the cover and cover_percentage of the sequence"""
         pass
 
-    def calculate_multifractal_analysis_values(self):
+    def calculate_multifractal_analysis_values(self, GCF):
         """Generate mfa generators, generate mfa values, attach the degrees of multifractality, the cover and cover
         percentage"""
-        self.generate_mfa()
+        self.generate_mfa(GCF)
         self.generate_degree_of_multifractality()
         self._attach_cover_data()
 
@@ -63,9 +63,9 @@ class SequenceManagerInterface:
         identified)"""
         pass
 
-    def calculate_and_graph(self):
+    def calculate_and_graph(self, GCF:str):
         """Generate MFA values and graph them along with the coverage"""
-        self.calculate_multifractal_analysis_values()
+        self.calculate_multifractal_analysis_values(GCF)
         self.graph_multifractal_analysis()
         self.graph_coverage()
 
@@ -79,6 +79,6 @@ class SequenceManagerInterface:
     def set_cover_percentage(self, cover_percentage):
         pass
 
-    def save_to_db_during_execution(self, GCF: str):
+    def save_results_to_db_during_execution(self, GCF: str):
        """ Save to DB after each sequence is executed"""
        pass

--- a/src/Biocode/mfa/CGR.py
+++ b/src/Biocode/mfa/CGR.py
@@ -110,8 +110,8 @@ class CGR:
             try:
                 self.mi_grid[row, col] += 1
             except:
-                print("Error here")
-                print("position:", current_position[0], ";", current_position[1], "epsilon:", epsilon, "row:", row,
+                logger.error("Error here")
+                logger.error("position:", current_position[0], ";", current_position[1], "epsilon:", epsilon, "row:", row,
                       "col:", col)
 
         self.sum_nucleotides = sum(x for x in self.cover if x > 0)

--- a/src/Biocode/services/AbstractService.py
+++ b/src/Biocode/services/AbstractService.py
@@ -6,7 +6,9 @@ class AbstractService:
     def insert(self, record: tuple) -> int :
         return DBConnectionManager.insert(table_name=self.table_name, columns=self.columns, pk=self.pk_column,
                                           record=record)
-
+    def update(self, pk_value, record: tuple) -> int:
+        return DBConnectionManager.update_when_null(table_name=self.table_name, columns=self.columns, pk_col=self.pk_column,
+                                          pk_value=pk_value, record=record)
     def extract_all(self):
         return DBConnectionManager.extract_all(table_name=self.table_name)
 

--- a/src/Biocode/services/RegionMiGridService.py
+++ b/src/Biocode/services/RegionMiGridService.py
@@ -2,11 +2,11 @@ from src.Biocode.services.AbstractService import AbstractService
 from src.Biocode.services.services_context.service_decorator import Service
 
 @Service
-class MiGridsService(AbstractService):
+class RegionMiGridsService(AbstractService):
     def __init__(self):
-        self.table_name = "mi_grids"
-        self.columns = ["mi_grid", "chromosome_id", "epsilon_size"]
+        self.table_name = "region_mi_grids"
+        self.columns = ["mi_grid", "region_chromosome_id", "epsilon_size"]
         self.pk_column = "id"
 
     def extract_mi_grid_by_chromosome_id(self, id: int):
-        return self.extract_by_field(column="chromosome_id", value=id).loc[0, 'mi_grid']
+        return self.extract_by_field(column="region_chromosome_id", value=id).loc[0, 'mi_grid']

--- a/src/Biocode/services/WholeChromosomesService.py
+++ b/src/Biocode/services/WholeChromosomesService.py
@@ -17,8 +17,13 @@ class WholeChromosomesService(AbstractService):
     def extract_by_refseq_accession_number(self, refseq_accession_number: str) -> str:
         return self.extract_by_field(column="refseq_accession_number", value=refseq_accession_number)
 
-    def extract_id_by_refseq_accession_number(self, refseq_accession_number: str) -> int:
-        return int(self.extract_by_field(column="refseq_accession_number", value=refseq_accession_number).loc[0, 'id'])
+    def extract_id_by_refseq_accession_number(self, refseq_accession_number: str) -> int | None:
+        result = self.extract_by_field(column="refseq_accession_number", value=refseq_accession_number)
+
+        if result is not None and not result.empty:
+            return int(result.loc[0, 'id'])
+        return None
+
 
     def extract_size_by_refseq_accession_number(self, refseq_accession_number: str) -> int:
         return int(self.extract_by_field(column="refseq_accession_number", value=refseq_accession_number).loc[0, 'size'])

--- a/src/Biocode/services/WholeMiGridsService.py
+++ b/src/Biocode/services/WholeMiGridsService.py
@@ -1,0 +1,23 @@
+from src.Biocode.services.AbstractService import AbstractService
+from src.Biocode.services.services_context.service_decorator import Service
+
+@Service
+class WholeMiGridsService(AbstractService):
+    def __init__(self):
+        self.table_name = "whole_mi_grids"
+        self.columns = ["mi_grid", "whole_chromosome_id", "epsilon_size"]
+        self.pk_column = "id"
+
+    def extract_mi_grid_by_chromosome_id(self, chromosome_id: int):
+        result = self.extract_by_field(column="whole_chromosome_id", value=int(chromosome_id))
+        return result.loc[0, 'mi_grid']
+
+    def get_whole_chromosome_id_if_mi_grid_exists_by_refseq_accession_number(self, refseq_accession_number):
+        query = f"SELECT wc.id AS id FROM whole_mi_grids JOIN whole_chromosomes wc on " \
+                f"whole_mi_grids.whole_chromosome_id = wc.id " \
+                f"WHERE refseq_accession_number='{refseq_accession_number}';"
+        result = self.extract_with_custom_query(query)
+        if result is None or result.empty:
+            return None
+        else:
+            return result.loc[0, 'id']


### PR DESCRIPTION
… be extracted from DB (for whole analysis)

Instead of using the mi_grids found that are in RAM memory. Extract the mi_grids from the DB and perform the MFA analysis as a separate operation from CGR execution and extracting mi_grid from database. Create additional methods, don't delete the current ones. Use the mi_grid saved in database if it already was created, execute the CGR algorithm and insert it into the database if it has not been inserted before.

Finding recursive kmers and executing analysis for regions is missing.

Created a RegionMiGridsService, separated MiGrids table into whole and regions, changed flow in services, added update method for DBConnectionManager.