### PR TITLE
ID-42: [Execute] Change the parameter -name when it is not the name b…

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ The second *source* is the path to the /lib folder where all the partitions of t
 ### RepeatMasker for a single sequence
 In the Docker container, go to the /working directory and execute the following command:
 
-    RepeatMasker -species nematode -dir /working/RM_resources/caenorhabditis_elegans /working/dna_sequences/Caenorhabditis_elegans/c_elegans_chromosome_X.fasta
+    RepeatMasker -species nematode -dir /working/RM_resources/caenorhabditis_elegans /working/dna_sequences/caenorhabditis_elegans/c_elegans_chromosome_X.fasta
 
 You can change the *-dir* parameter to change the destination folder. The next parameter is the path to the .fasta or 
 .fna sequence.
@@ -125,7 +125,7 @@ The graphs are saved in the /out directory in the sequence folder.
 
 It is mandatory to specify the
 - path of the RM results file.
-  - name - scientific name of the organism that will be used as the folder name to save the graph.
+- dir - scientific name of the organism that will be used as the folder name to save the graph.
 
 Other possible parameters are:
 - partitions - number of partitions to use in the graph generation. Each partition will represent one point in the graph.
@@ -134,11 +134,11 @@ Other possible parameters are:
   - plot_type - style of plot (line or bar), line is by default.
   - save - save the graph in the local directory specified /out (true or false).
 
-         py .\command.py graph_rm_file_sequence -path resources/RM_resources/caenorhabditis_elegans/c_elegans_chromosome_I.fasta.out -partitions 300 -regions 3 -plot_type line -name "caenorhabditis_elegans" --save true
+         py .\command.py graph_rm_file_sequence -path resources/RM_resources/caenorhabditis_elegans/c_elegans_chromosome_I.fasta.out -partitions 300 -regions 3 -plot_type line -dir caenorhabditis_elegans --save true
         
 The command without the optional parameters would be:
 
-       py .\command.py graph_rm_file_sequence -path resources/RM_resources/caenorhabditis_elegans/c_elegans_chromosome_I.fasta.out -name "caenorhabditis_elegans" 
+       py .\command.py graph_rm_file_sequence -path resources/RM_resources/caenorhabditis_elegans/c_elegans_chromosome_I.fasta.out -dir caenorhabditis_elegans
  
 #### Graphing using a genome folder of .out result files 
 It is mandatory to specify the
@@ -152,11 +152,11 @@ Other possible parameters are:
   - plot_type - style of plot (line or bar), line is by default.
   - save - save the graph in the local directory specified /out (true or false).
 
-         py .\command.py graph_rm_file_genome -path resources/RM_resources/caenorhabditis_elegans -partitions 300 -regions 3 -plot_type line -name "caenorhabditis_elegans" --save true
+         py .\command.py graph_rm_file_genome -path resources/RM_resources/caenorhabditis_elegans -partitions 300 -regions 3 -plot_type line -dir caenorhabditis_elegans --save true
         
 The command without the optional parameters would be:
 
-       py .\command.py graph_rm_file_genome -path resources/RM_resources/caenorhabditis_elegans -name "caenorhabditis_elegans" 
+       py .\command.py graph_rm_file_genome -path resources/RM_resources/caenorhabditis_elegans -dir caenorhabditis_elegans 
 
 ### Graph the Plantrep.cn repeats using the file
 The graphs are saved in the /out directory in the sequence folder. 
@@ -194,11 +194,11 @@ Other possible parameters are:
   - plot_type - style of plot (line or bar), line is by default.
   - save - save the graph in the local directory specified /out (true or false).
 
-         py .\command.py graph_rm_database_sequence -ran NC_003279.8 -partitions 300 -regions 3 -plot_type line -name "caenorhabditis_elegans" --save true
+         py .\command.py graph_rm_database_sequence -ran NC_003279.8 -partitions 300 -regions 3 -plot_type line -dir caenorhabditis_elegans --save true
 
 The command without the optional parameters would be:
 
-       py .\command.py graph_rm_database_sequence -ran NC_003279.8 -name "caenorhabditis_elegans" 
+       py .\command.py graph_rm_database_sequence -ran NC_003279.8 -dir caenorhabditis_elegans
 
 #### Graphing using a genome GCF and the database
 It is mandatory to specify the
@@ -212,11 +212,11 @@ Other possible parameters are:
   - plot_type - style of plot (line or bar), line is by default.
   - save - save the graph in the local directory specified /out (true or false).
 
-         py .\command.py graph_rm_database_genome -gcf GCF_000002985.6 -partitions 300 -regions 3 -plot_type line -name "caenorhabditis_elegans" --save true
+         py .\command.py graph_rm_database_genome -gcf GCF_000002985.6 -partitions 300 -regions 3 -plot_type line -dir caenorhabditis_elegans --save true
         
 The command without the optional parameters would be:
 
-       py .\command.py graph_rm_database_genome -gcf GCF_000002985.6 -name "caenorhabditis_elegans" 
+       py .\command.py graph_rm_database_genome -gcf GCF_000002985.6 -dir caenorhabditis_elegans
 
 
 ### Graph the recursively found repeats results from the database
@@ -233,8 +233,8 @@ The chromosome is identified by the refseq_accession_number (-ran)
 The n_max parameter is optional. It represents the total amount of repeats shown in the general graphs.
 The genome is identified by the GCF (-gcf).
 
-    py .\command.py graph_recursive_genome -gcf GCF_000002985.6 --save true -name "caenorhabditis_elegans" 
-    py .\command.py graph_recursive_genome -gcf GCF_000002985.6 --save true -name "caenorhabditis_elegans" -n_max 10
+    py .\command.py graph_recursive_genome -gcf GCF_000002985.6 --save true -dir caenorhabditis_elegans 
+    py .\command.py graph_recursive_genome -gcf GCF_000002985.6 --save true -dir caenorhabditis_elegans -n_max 10
 
 ### Graph genes data
 #### Graph from .gtf file
@@ -251,11 +251,11 @@ Other possible parameters are:
 
 Example using the command:
 
-    py .\command.py graph_gtf_file -path  resources/genes/caenorhabditis_elegans/gtf/GCF_000002985.6_WBcel235_genomic.gtf -partitions 300 -regions 3 -plot_type line -name "caenorhabditis_elegans" --save true
+    py .\command.py graph_gtf_file -path  resources/genes/caenorhabditis_elegans/gtf/GCF_000002985.6_WBcel235_genomic.gtf -partitions 300 -regions 3 -plot_type line -dir caenorhabditis_elegans --save true
 
 Short version:
 
-    py .\command.py graph_gtf_file -path  resources/genes/caenorhabditis_elegans/gtf/GCF_000002985.6_WBcel235_genomic.gtf -name "caenorhabditis_elegans" 
+    py .\command.py graph_gtf_file -path  resources/genes/caenorhabditis_elegans/gtf/GCF_000002985.6_WBcel235_genomic.gtf -dir caenorhabditis_elegans
 
 #### Graph from database
 It is mandatory to specify the
@@ -275,13 +275,13 @@ Other possible parameters are:
 
 Example using the command:
 
-    py .\command.py graph_gtf_database -gcf GCF_000002985.6 -partitions 300 -regions 3 -plot_type line -name "caenorhabditis_elegans" --save true
+    py .\command.py graph_gtf_database -gcf GCF_000002985.6 -partitions 300 -regions 3 -plot_type line -dir caenorhabditis_elegans --save true
 
 Short version:
 
-    py .\command.py graph_gtf_database -gcf GCF_000002985.6 -name "caenorhabditis_elegans"  
-    py .\command.py graph_gtf_database -ran NC_003279.8  -name "caenorhabditis_elegans"  
-    py .\command.py graph_gtf_database -ran NC_003279.8  -name "caenorhabditis_elegans" -gcf anything_here
+    py .\command.py graph_gtf_database -gcf GCF_000002985.6 -dir caenorhabditis_elegans
+    py .\command.py graph_gtf_database -ran NC_003279.8  -dir caenorhabditis_elegans 
+    py .\command.py graph_gtf_database -ran NC_003279.8  -dir caenorhabditis_elegans -gcf anything_here
 
 
 ## Repeats using RepeatMasker

--- a/command.py
+++ b/command.py
@@ -53,7 +53,7 @@ def main():
     graph_rm_file_parser.add_argument('-regions', help="Enter the amount of regions to separate the graph using vertical lines")
     graph_rm_file_parser.add_argument('-plot_type', help="Plot type: line or bar")
     graph_rm_file_parser.add_argument('--save', choices=['true', 'false'], default='true', help='Save graphs locally in /out directory')
-    graph_rm_file_parser.add_argument('-name', help="Enter the scientific name of the organism to use it as a folder name")
+    graph_rm_file_parser.add_argument('-dir', help="Enter the scientific name of the organism to use it as a folder name")
 
     graph_rm_database_parser = subparsers.add_parser('graph_rm_database_sequence', help='Graph RepeatMasker results')
     graph_rm_database_parser.add_argument('-ran', help="Enter the refseq accession number of the sequence/chromosome")
@@ -65,7 +65,7 @@ def main():
     graph_rm_database_parser.add_argument('-plot_type', help="Plot type: line or bar")
     graph_rm_database_parser.add_argument('--save', choices=['true', 'false'], default='true',
                                       help='Save graphs locally in /out directory')
-    graph_rm_database_parser.add_argument('-name',
+    graph_rm_database_parser.add_argument('-dir',
                                       help="Enter the scientific name of the organism to use it as a folder name")
 
 
@@ -79,7 +79,7 @@ def main():
     graph_rm_file_genome_parser.add_argument('-plot_type', help="Plot type: line or bar")
     graph_rm_file_genome_parser.add_argument('--save', choices=['true', 'false'], default='true',
                                       help='Save graphs locally in /out directory')
-    graph_rm_file_genome_parser.add_argument('-name',
+    graph_rm_file_genome_parser.add_argument('-dir',
                                       help="Enter the scientific name of the organism to use it as a folder name")
 
     graph_rm_database_genome_parser = subparsers.add_parser('graph_rm_database_genome',
@@ -93,7 +93,7 @@ def main():
     graph_rm_database_genome_parser.add_argument('-plot_type', help="Plot type: line or bar")
     graph_rm_database_genome_parser.add_argument('--save', choices=['true', 'false'], default='true',
                                              help='Save graphs locally in /out directory')
-    graph_rm_database_genome_parser.add_argument('-name',
+    graph_rm_database_genome_parser.add_argument('-dir',
                                              help="Enter the scientific name of the organism to use it as a folder name")
 
     graph_genome_repeats_from_file = subparsers.add_parser('graph_genome_repeats_from_file', help='Graph genome repeats results from'
@@ -123,7 +123,7 @@ def main():
     graph_recursive_genome_parser.add_argument('-gcf', help="Enter the GCF id of the organism")
     graph_recursive_genome_parser.add_argument('--save', choices=['true', 'false'], default='true',
                                           help='Save graphs locally in /out directory')
-    graph_recursive_genome_parser.add_argument('-name',
+    graph_recursive_genome_parser.add_argument('-dir',
                                           help="Enter the scientific name of the organism to use it as a folder name")
     graph_recursive_genome_parser.add_argument('-n_max', help="(Optional) Graph only the top n largest values per sequence")
 
@@ -138,7 +138,7 @@ def main():
     graph_gtf_file_parser.add_argument('-plot_type', help="Plot type: line or bar")
     graph_gtf_file_parser.add_argument('--save', choices=['true', 'false'], default='true',
                                       help='Save graphs locally in /out directory')
-    graph_gtf_file_parser.add_argument('-name',
+    graph_gtf_file_parser.add_argument('-dir',
                                       help="Enter the scientific name of the organism to use it as a folder name")
 
     graph_gtf_file_parser = subparsers.add_parser('graph_gtf_database', help='Graph genes from .gtf file')
@@ -152,7 +152,7 @@ def main():
     graph_gtf_file_parser.add_argument('-plot_type', help="Plot type: line or bar")
     graph_gtf_file_parser.add_argument('--save', choices=['true', 'false'], default='true',
                                        help='Save graphs locally in /out directory')
-    graph_gtf_file_parser.add_argument('-name',
+    graph_gtf_file_parser.add_argument('-dir',
                                        help="Enter the scientific name of the organism to use it as a folder name")
 
 
@@ -283,23 +283,23 @@ def load_genome_repeats_file_command(args):
 @TryExcept
 def graph_rm_file_command(args):
     graph_rm_results_from_file(path=args.path, partitions=args.partitions, regions=args.regions,
-                                   plot_type=args.plot_type, save=args.save, name=args.name)
+                                   plot_type=args.plot_type, save=args.save, dir=args.dir)
 
 @TryExcept
 def graph_rm_database_command(args):
     graph_rm_results_from_database(refseq_accession_number=args.ran, partitions=args.partitions,
-                                   regions=args.regions, plot_type=args.plot_type, save=args.save, name=args.name)
+                                   regions=args.regions, plot_type=args.plot_type, save=args.save, dir=args.dir)
 
 
 @TryExcept
 def graph_rm_file_genome_command(args):
     graph_rm_results_from_files_in_folder(directory_path=args.path, partitions=args.partitions, regions=args.regions,
-                                              plot_type=args.plot_type, save=args.save, name=args.name)
+                                              plot_type=args.plot_type, save=args.save, dir=args.dir)
 
 @TryExcept
 def graph_rm_database_genome_command(args):
     graph_rm_results_of_genome_from_database(GCF=args.gcf, partitions=args.partitions, regions=args.regions,
-                                                 plot_type=args.plot_type, save=args.save, name=args.name)
+                                                 plot_type=args.plot_type, save=args.save, dir=args.dir)
 @TryExcept
 def graph_genome_repeats_from_file_command(args):
     graph_genome_repeats_from_file(path=args.path, dir=args.dir, partitions=args.partitions, regions=args.regions,
@@ -311,18 +311,18 @@ def graph_recursive_command(args):
 
 @TryExcept
 def graph_recursive_genome_command(args):
-    graph_recursive_genome_from_database(GCF=args.gcf, save=args.save, name=args.name, n_max=args.n_max)
+    graph_recursive_genome_from_database(GCF=args.gcf, save=args.save, dir=args.dir, n_max=args.n_max)
 
 
 @TryExcept
 def graph_gtf_file(args):
     graph_gtf_from_file(path=args.path, partitions=args.partitions, regions=args.regions, plot_type=args.plot_type,
-                            save=args.save, name=args.name)
+                            save=args.save, dir=args.dir)
 
 @TryExcept
 def graph_gtf_database(args):
     graph_gtf_from_database(GCF=args.gcf, refseq_accession_number=args.ran, partitions=args.partitions,
-                                regions=args.regions, plot_type=args.plot_type, save=args.save, name=args.name)
+                                regions=args.regions, plot_type=args.plot_type, save=args.save, dir=args.dir)
 
 @TryExcept
 def  load_genes(args):

--- a/graph.py
+++ b/graph.py
@@ -130,7 +130,7 @@ def graph_regions(dataframe, organism_name, data, regions_number):
 @DBConnection
 @Timer
 def graph_rm_results_from_file(path: str, partitions:int, regions: int,
-                               plot_type:str = "line", save: bool = True, name: str = None):
+                               plot_type:str = "line", save: bool = True, dir: str = None):
     DEFAULT_REGIONS = 3
     DEFAULT_PARTITIONS = 300
     DEFAULT_REPEATS_LIMIT = 20
@@ -151,45 +151,45 @@ def graph_rm_results_from_file(path: str, partitions:int, regions: int,
     if graphs_config.get('distribution_of_repeats_merged', False):
         Graphs.graph_distribution_of_repeats_merged_from_file(
             df=df, size=size, partitions=partitions, regions=regions,
-            plot_type=plot_type, save=save, name=name, filename=filename)
+            plot_type=plot_type, save=save, name=dir, filename=filename)
 
     if graphs_config.get('frequency_of_repeats_class_family', False):
         Graphs.graph_frequency_of_repeats_grouped_from_file(
             df=df, col="class_family", filtering=False, n_max=10,
-            save=save, name=name, filename=filename)
+            save=save, name=dir, filename=filename)
 
     if graphs_config.get('frequency_of_repeats_repeat', False):
         Graphs.graph_frequency_of_repeats_grouped_from_file(
             df=df, col="repeat", filtering=False, n_max=10,
-            save=save, name=name, filename=filename)
+            save=save, name=dir, filename=filename)
 
     if graphs_config.get('distribution_of_repeats_class_family', False):
         Graphs.graph_distribution_of_repeats_from_file(
             df=df, col="class_family", legend=True, plot_type=plot_type,
             limit=DEFAULT_REPEATS_LIMIT, regions=regions, save=save,
-            name=name, filename=filename)
+            name=dir, filename=filename)
 
     if graphs_config.get('distribution_of_repeats_repeat', False):
         Graphs.graph_distribution_of_repeats_from_file(
             df=df, col="repeat", legend=True, plot_type=plot_type,
             limit=DEFAULT_REPEATS_LIMIT, regions=regions, save=save,
-            name=name, filename=filename)
+            name=dir, filename=filename)
 
     if graphs_config.get('distribution_of_repeats_subplots_class_family', False):
         Graphs.graph_distribution_of_repeats_subplots_from_file(
             df=df, col="class_family", legend=True, limit=DEFAULT_REPEATS_LIMIT,
-            regions=regions, save=save, name=name, filename=filename)
+            regions=regions, save=save, name=dir, filename=filename)
 
     if graphs_config.get('distribution_of_repeats_subplots_repeat', False):
         Graphs.graph_distribution_of_repeats_subplots_from_file(
             df=df, col="repeat", legend=True, limit=DEFAULT_REPEATS_LIMIT,
-            regions=regions, save=save, name=name, filename=filename)
+            regions=regions, save=save, name=dir, filename=filename)
 
 
 @DBConnection
 @Timer
 def graph_rm_results_from_database(refseq_accession_number:str, partitions:int, regions: int,
-                               plot_type:str = "line", save: bool = True, name: str = None):
+                                   plot_type:str = "line", save: bool = True, dir: str = None):
     DEFAULT_REGIONS = 3
     DEFAULT_PARTITIONS = 300
     DEFAULT_REPEATS_LIMIT = 20
@@ -210,56 +210,56 @@ def graph_rm_results_from_database(refseq_accession_number:str, partitions:int, 
     if graphs_config.get('distribution_of_repeats_merged', False):
         Graphs.graph_distribution_of_repeats_merged_from_database(
             data=data, size=size, partitions=partitions, regions=regions,
-            plot_type=plot_type, save=save, name=name, filename=filename)
+            plot_type=plot_type, save=save, name=dir, filename=filename)
 
     if graphs_config.get('frequency_of_repeats_class_family', False):
         Graphs.graph_frequency_of_repeats_grouped_from_database(
             data=data, col="class_family", filtering=False, n_max=10,
-            save=save, name=name, filename=filename)
+            save=save, name=dir, filename=filename)
 
     if graphs_config.get('frequency_of_repeats_repeat', False):
         Graphs.graph_frequency_of_repeats_grouped_from_database(
             data=data, col="repeat", filtering=False, n_max=10,
-            save=save, name=name, filename=filename)
+            save=save, name=dir, filename=filename)
 
     if graphs_config.get('distribution_of_repeats_class_family', False):
         Graphs.graph_distribution_of_repeats_from_database(
             data=data, col="class_family", legend=True, plot_type=plot_type,
             limit=DEFAULT_REPEATS_LIMIT, regions=regions, save=save,
-            name=name, filename=filename)
+            name=dir, filename=filename)
 
     if graphs_config.get('distribution_of_repeats_repeat', False):
         Graphs.graph_distribution_of_repeats_from_database(
             data=data, col="repeat", legend=True, plot_type=plot_type,
             limit=DEFAULT_REPEATS_LIMIT, regions=regions, save=save,
-            name=name, filename=filename)
+            name=dir, filename=filename)
 
     if graphs_config.get('distribution_of_repeats_subplots_class_family', False):
         Graphs.graph_distribution_of_repeats_subplots_from_database(
             data=data, col="class_family", legend=True, limit=DEFAULT_REPEATS_LIMIT,
-            regions=regions, save=save, name=name, filename=filename)
+            regions=regions, save=save, name=dir, filename=filename)
 
     if graphs_config.get('distribution_of_repeats_subplots_repeat', False):
         Graphs.graph_distribution_of_repeats_subplots_from_database(
             data=data, col="repeat", legend=True, limit=DEFAULT_REPEATS_LIMIT,
-            regions=regions, save=save, name=name, filename=filename)
+            regions=regions, save=save, name=dir, filename=filename)
 
 @DBConnection
 @Timer
 def graph_rm_results_from_files_in_folder(directory_path: str, partitions: int, regions: int, plot_type: str, save: bool,
-                                          name: str):
+                                          dir: str):
     apply_function_to_files_in_folder(directory_path, graph_rm_results_from_file, partitions, regions,
-                                      plot_type, save, name)
+                                      plot_type, save, dir)
 
 @DBConnection
 @Timer
 def graph_rm_results_of_genome_from_database(GCF: str, partitions: int, regions: int, plot_type: str, save: bool,
-                                             name: str):
+                                             dir: str):
     organisms_service = OrganismsService()
     chromosomes_ran_list = organisms_service.extract_chromosomes_refseq_accession_numbers_by_GCF(GCF)
 
     for refseq_accession_number in chromosomes_ran_list:
-        graph_rm_results_from_database(refseq_accession_number, partitions, regions, plot_type, save, name)
+        graph_rm_results_from_database(refseq_accession_number, partitions, regions, plot_type, save, dir)
 
 @DBConnection
 @Timer
@@ -354,17 +354,17 @@ def graph_recursive_from_database(refseq_accession_number: str, save: bool, name
 
 @DBConnection
 @Timer
-def graph_recursive_genome_from_database(GCF: str, save: bool, name: str, n_max: int):
+def graph_recursive_genome_from_database(GCF: str, save: bool, dir: str, n_max: int):
     n_max = n_max and int(n_max)
     organism_service = OrganismsService()
     refseq_accession_numbers = organism_service.extract_chromosomes_refseq_accession_numbers_by_GCF(GCF)
 
     for refseq_accession_number in refseq_accession_numbers:
-        graph_recursive_from_database(refseq_accession_number, save, name, n_max)
+        graph_recursive_from_database(refseq_accession_number, save, dir, n_max)
 
 @DBConnection
 @Timer
-def graph_gtf_from_file(path: str, partitions: int, regions: int, plot_type: str, save: bool, name: str, config_path: str = "config.yaml"):
+def graph_gtf_from_file(path: str, partitions: int, regions: int, plot_type: str, save: bool, dir: str):
     DEFAULT_REGIONS = 3
     DEFAULT_PARTITIONS = 300
 
@@ -393,12 +393,12 @@ def graph_gtf_from_file(path: str, partitions: int, regions: int, plot_type: str
 
         if graphs_config.get('distribution_of_genes_merged', False):
             Graphs.graph_distribution_of_genes_merged(
-                df, name, size, partitions, regions, plot_type, chromosome_name, bool(save)
+                df, dir, size, partitions, regions, plot_type, chromosome_name, bool(save)
             )
 
         if graphs_config.get('distribution_of_genes', False):
             Graphs.graph_distribution_of_genes(
-                df, name, legend=True, plot_type=plot_type, limit=20, regions=regions,
+                df, dir, legend=True, plot_type=plot_type, limit=20, regions=regions,
                 chromosome_name=chromosome_name, save=bool(save)
             )
 
@@ -423,7 +423,7 @@ def _graph_gtf_single_chromosome_from_database(refseq_accession_number: str, nam
 @DBConnection
 @Timer
 def graph_gtf_from_database(GCF: str, refseq_accession_number: str, partitions: int, regions: int, plot_type: str,
-                            save: bool, name: str):
+                            save: bool, dir: str):
     DEFAULT_REGIONS = 3
     DEFAULT_PARTITIONS = 300
 
@@ -433,18 +433,18 @@ def graph_gtf_from_database(GCF: str, refseq_accession_number: str, partitions: 
 
     if GCF:
         if refseq_accession_number:
-           _graph_gtf_single_chromosome_from_database(refseq_accession_number, name, partitions, regions, plot_type,
+           _graph_gtf_single_chromosome_from_database(refseq_accession_number, dir, partitions, regions, plot_type,
                                                       save)
         else:
             organisms_service = OrganismsService()
             chromosomes_ran_list = organisms_service.extract_chromosomes_refseq_accession_numbers_by_GCF(GCF)
             logger.info(f"Graphing for the genome: {GCF}")
             for refseq_accession_number in chromosomes_ran_list:
-                _graph_gtf_single_chromosome_from_database(refseq_accession_number, name, partitions, regions,
+                _graph_gtf_single_chromosome_from_database(refseq_accession_number, dir, partitions, regions,
                                                            plot_type, save)
     elif refseq_accession_number:
-        _graph_gtf_single_chromosome_from_database(refseq_accession_number, name, partitions, regions, plot_type,
-                                                       save)
+        _graph_gtf_single_chromosome_from_database(refseq_accession_number, dir, partitions, regions, plot_type,
+                                                   save)
     else:
         logger.error("Specify whether a GCF (organism/genome) or a refseq accession number (sequence/chromosome)")
         return


### PR DESCRIPTION
…ut the directory

Some commands use the parameter "name" as "Musa acuminata" and others as "musa_acuminata". The name must be used only when the organism name according to sequences.yaml file is needed. When using a directory path, change the name variable (working with results files).