### PR TITLE
ID-45: [Execute] Separate .gtf file in another folder when downloading

### DIFF
--- a/Loader.py
+++ b/Loader.py
@@ -115,7 +115,7 @@ class Loader:
             logger.error("Invalid download url %s", e)
             return ""
 
-    def get_download_gff_url(self) -> str:
+    def get_download_gtf_url(self) -> str:
         try:
             return self.config[self.organism]['download_files_url']
         except KeyError as e:

--- a/command.py
+++ b/command.py
@@ -154,8 +154,8 @@ def main():
     download_parser = subparsers.add_parser('download', help='Download command: it downloads the chromosomes files form the link'
                                                              'specified in the sequences.yaml file.')
     download_parser.add_argument('-name', help='Name or GCF for downloading')
-    download_parser.add_argument('--gff', choices=['true', 'false'], default='true',
-                                      help='Save the genes .gff file from the link specified in the sequence.yaml file')
+    download_parser.add_argument('--gtf', choices=['true', 'false'], default='true',
+                                      help='Save the genes .gtf file from the link specified in the sequence.yaml file')
 
     load_RM_repeats_parser = subparsers.add_parser('load_RM_repeats', help='Load repeats from results file generated '
                                             'by RepeatMasker')


### PR DESCRIPTION
Make the separation of the .gtf files in the "genes/organism" folder and subfolder, but working when executing the download command.